### PR TITLE
Added option to print logs to file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ install_requires =
     importlib           ; python_version>"3.8"
     argparse                      # Python Argument Parser
     argcomplete                   # Autocompletion Argparse
+    json
     rasterio
     scikit-image
     scikit-learn

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,6 @@ install_requires =
     importlib           ; python_version>"3.8"
     argparse                      # Python Argument Parser
     argcomplete                   # Autocompletion Argparse
-    json
     rasterio
     scikit-image
     scikit-learn

--- a/slurp/masks/shadowmask.py
+++ b/slurp/masks/shadowmask.py
@@ -26,6 +26,7 @@ This script computes a shadow mask
 import argparse
 import time
 import traceback
+import logging
 from os import makedirs, path
 
 import eoscale.eo_executors as eoexe
@@ -37,6 +38,7 @@ from slurp.tools import eoscale_utils as eo_utils
 from slurp.tools import io_utils, utils
 from slurp.tools.constant import NODATA_INT8
 
+logger = logging.getLogger("slurp")
 
 def compute_shadowmask(
     input_buffers: list, input_profiles: list, params: dict
@@ -179,8 +181,8 @@ def main():
         if argparse_dict[key] is not None:
             argsdict[key] = argparse_dict[key]
 
-    print("JSON data loaded:")
-    print(argsdict)
+    logger.info("JSON data loaded:")
+    logger.info(argsdict)
     args = argparse.Namespace(**argsdict)
 
     # Create output folder
@@ -270,28 +272,28 @@ def main():
             eoscale_manager.write(key=mask_shadow[0], img_path=args.shadowmask)
 
             end_time = time.time()
-            print(
+            logger.info(
                 f"**** Shadow mask for {args.file_vhr} (saved as {args.shadowmask}) ****"
             )
-            print(
+            logger.info(
                 "Total time (user)       :\t"
                 + utils.convert_time(end_time - t0)
             )
 
         except FileNotFoundError as fnfe_exception:
-            print("FileNotFoundError", fnfe_exception)
+            logger.error("FileNotFoundError", fnfe_exception)
 
         except PermissionError as pe_exception:
-            print("PermissionError", pe_exception)
+            logger.error("PermissionError", pe_exception)
 
         except ArithmeticError as ae_exception:
-            print("ArithmeticError", ae_exception)
+            logger.error("ArithmeticError", ae_exception)
 
         except MemoryError as me_exception:
-            print("MemoryError", me_exception)
+            logger.error("MemoryError", me_exception)
 
         except Exception as exception:  # pylint: disable=broad-except
-            print("oups...", exception)
+            logger.error("oups...", exception)
             traceback.print_exc()
 
 

--- a/slurp/masks/shadowmask.py
+++ b/slurp/masks/shadowmask.py
@@ -190,9 +190,11 @@ def main():
     args = argparse.Namespace(**argsdict)
 
     if args.logs_to_file:
-        config_file = pathlib.Path("logs/out2stdout.json")
+        config_file = pathlib.Path("slurp/tools/logs/out2json.json")
+        if not path.exists("logs"):
+            makedirs("logs")
     else:
-        config_file = pathlib.Path("logs/out2json.json")
+        config_file = pathlib.Path("slurp/tools/logs/out2stdout.json")
     utils.setup_logging(config_file)
 
     logger.info("JSON data loaded:")

--- a/slurp/masks/shadowmask.py
+++ b/slurp/masks/shadowmask.py
@@ -27,6 +27,7 @@ import argparse
 import time
 import traceback
 import logging
+import pathlib
 from os import makedirs, path
 
 import eoscale.eo_executors as eoexe
@@ -95,6 +96,11 @@ def getarguments():
     parser.add_argument(
         "main_config", help="First JSON file, load basis arguments"
     )
+    parser.add_argument("-log_f",
+                        "--logs_to_file",
+                        action="store_true",
+                        help="Store all logs to a file, instead of stdout",
+                        )
 
     group1 = parser.add_argument_group(description="*** INPUT FILES ***")
     group1.add_argument(
@@ -181,9 +187,16 @@ def main():
         if argparse_dict[key] is not None:
             argsdict[key] = argparse_dict[key]
 
+    args = argparse.Namespace(**argsdict)
+
+    if args.logs_to_file:
+        config_file = pathlib.Path("logs/out2stdout.json")
+    else:
+        config_file = pathlib.Path("logs/out2json.json")
+    utils.setup_logging(config_file)
+
     logger.info("JSON data loaded:")
     logger.info(argsdict)
-    args = argparse.Namespace(**argsdict)
 
     # Create output folder
     makedirs(path.dirname(args.shadowmask), exist_ok=True)

--- a/slurp/masks/stack_masks.py
+++ b/slurp/masks/stack_masks.py
@@ -31,6 +31,7 @@ import argparse
 import time
 import traceback
 import logging
+import pathlib
 from os import makedirs, path
 
 import eoscale.eo_executors as eoexe
@@ -212,6 +213,11 @@ def getarguments():
     parser.add_argument(
         "main_config", help="First JSON file, load basis arguments"
     )
+    parser.add_argument("-log_f",
+                        "--logs_to_file",
+                        action="store_true",
+                        help="Store all logs to a file, instead of stdout",
+                        )
 
     group1 = parser.add_argument_group(description="*** INPUT FILES ***")
     group1.add_argument(
@@ -337,9 +343,16 @@ def main():
         if argparse_dict[key] is not None:
             argsdict[key] = argparse_dict[key]
 
+    args = argparse.Namespace(**argsdict)
+
+    if args.logs_to_file:
+        config_file = pathlib.Path("logs/out2stdout.json")
+    else:
+        config_file = pathlib.Path("logs/out2json.json")
+    utils.setup_logging(config_file)
+
     logger.info("JSON data loaded:")
     logger.info(argsdict)
-    args = argparse.Namespace(**argsdict)
 
     # Create output folder
     makedirs(path.dirname(args.stackmask), exist_ok=True)

--- a/slurp/masks/stack_masks.py
+++ b/slurp/masks/stack_masks.py
@@ -30,6 +30,7 @@ Final mask values
 import argparse
 import time
 import traceback
+import logging
 from os import makedirs, path
 
 import eoscale.eo_executors as eoexe
@@ -43,6 +44,7 @@ from slurp.tools import eoscale_utils as eo_utils
 from slurp.tools import io_utils, utils
 from slurp.tools.constant import HIGH, LOW, NODATA_INT8
 
+logger = logging.getLogger("slurp")
 
 def watershed_regul_buildings(
     input_image, urbanmask, wsf, vegmask, watermask, shadowmask, params
@@ -335,8 +337,8 @@ def main():
         if argparse_dict[key] is not None:
             argsdict[key] = argparse_dict[key]
 
-    print("JSON data loaded:")
-    print(argsdict)
+    logger.info("JSON data loaded:")
+    logger.info(argsdict)
     args = argparse.Namespace(**argsdict)
 
     # Create output folder
@@ -395,25 +397,25 @@ def main():
             eoscale_manager.write(key=final_mask[0], img_path=args.stackmask)
 
             t1 = time.time()
-            print(
+            logger.info(
                 f"**** Stack masks for {args.file_vhr} (saved as {args.stackmask}) ****"
             )
-            print("Total time (user)       :\t" + utils.convert_time(t1 - t0))
+            logger.info("Total time (user)       :\t" + utils.convert_time(t1 - t0))
 
         except FileNotFoundError as fnfe_exception:
-            print("FileNotFoundError", fnfe_exception)
+            logger.error("FileNotFoundError", fnfe_exception)
 
         except PermissionError as pe_exception:
-            print("PermissionError", pe_exception)
+            logger.error("PermissionError", pe_exception)
 
         except ArithmeticError as ae_exception:
-            print("ArithmeticError", ae_exception)
+            logger.error("ArithmeticError", ae_exception)
 
         except MemoryError as me_exception:
-            print("MemoryError", me_exception)
+            logger.error("MemoryError", me_exception)
 
         except Exception as exception:  # pylint: disable=broad-except
-            print("oups...", exception)
+            logger.error("oups...", exception)
             traceback.print_exc()
 
 

--- a/slurp/masks/stack_masks.py
+++ b/slurp/masks/stack_masks.py
@@ -346,9 +346,11 @@ def main():
     args = argparse.Namespace(**argsdict)
 
     if args.logs_to_file:
-        config_file = pathlib.Path("logs/out2stdout.json")
+        config_file = pathlib.Path("slurp/tools/logs/out2json.json")
+        if not path.exists("logs"):
+            makedirs("logs")
     else:
-        config_file = pathlib.Path("logs/out2json.json")
+        config_file = pathlib.Path("slurp/tools/logs/out2stdout.json")
     utils.setup_logging(config_file)
 
     logger.info("JSON data loaded:")

--- a/slurp/masks/urbanmask.py
+++ b/slurp/masks/urbanmask.py
@@ -388,9 +388,11 @@ def main():
     args = argparse.Namespace(**argsdict)
 
     if args.logs_to_file:
-        config_file = pathlib.Path("logs/out2stdout.json")
+        config_file = pathlib.Path("slurp/tools/logs/out2json.json")
+        if not path.exists("logs"):
+            makedirs("logs")
     else:
-        config_file = pathlib.Path("logs/out2json.json")
+        config_file = pathlib.Path("slurp/tools/logs/out2stdout.json")
     utils.setup_logging(config_file)
 
     logger.info("JSON data loaded:")
@@ -534,11 +536,9 @@ def main():
                         n_jobs=args.n_jobs,
                     )
                     logger.info(
-                        "RandomForest parameters:\n",
-                        classifier.get_params(),
-                        "\n",
+                        "RandomForest parameters: \n%s\n",
+                        str(classifier.get_params())
                     )
-
                     random_forest_utils.train_classifier(classifier, x_samples, y_samples)
                     random_forest_utils.print_feature_importance(
                         classifier, args.files_layers

--- a/slurp/masks/urbanmask.py
+++ b/slurp/masks/urbanmask.py
@@ -24,6 +24,7 @@ import argparse
 import gc
 import time
 import traceback
+import logging
 from os import makedirs, path
 
 import eoscale.eo_executors as eoexe
@@ -37,12 +38,15 @@ from slurp.tools import eoscale_utils as eo_utils
 from slurp.tools import io_utils, utils
 from slurp.tools.constant import NODATA_INT8
 
+logger = logging.getLogger("slurp")
+
 try:
     from sklearnex import patch_sklearn
 
     patch_sklearn()
 except ModuleNotFoundError:
-    print("Intel(R) Extension/Optimization for scikit-learn not found.")
+    logger.error("Intel(R) Extension/Optimization for scikit-learn not found.")
+
 
 
 def apply_vegetationmask(
@@ -375,8 +379,8 @@ def main():
         if argparse_dict[key] is not None:
             argsdict[key] = argparse_dict[key]
 
-    print("JSON data loaded:")
-    print(argsdict)
+    logger.info("JSON data loaded:")
+    logger.info(argsdict)
     args = argparse.Namespace(**argsdict)
 
     # Create output folder
@@ -397,7 +401,6 @@ def main():
             # Image PHR (numpy array, 4 bands, band number is first dimension),
             key_phr = eoscale_manager.open_raster(raster_path=args.file_vhr)
             profile_phr = eoscale_manager.get_profile(key_phr)
-            eo_utils.print_dataset_infos(args.file_vhr, profile_phr, "PHR")
 
             # Valid stack
             key_original_valid_stack = eoscale_manager.open_raster(
@@ -517,7 +520,7 @@ def main():
                         random_state=0,
                         n_jobs=args.n_jobs,
                     )
-                    print(
+                    logger.info(
                         "RandomForest parameters:\n",
                         classifier.get_params(),
                         "\n",
@@ -562,30 +565,30 @@ def main():
 
                     end_time = time.time()
 
-                    print(
+                    logger.info(
                         f"**** Urban proba mask for {args.file_vhr} (saved as {args.urbanmask}) ****"
                     )
-                    print(
+                    logger.info(
                         "Total time (user)       :\t"
                         + utils.convert_time(end_time - t0)
                     )
-                    print(
+                    logger.info(
                         "- Build_stack           :\t"
                         + utils.convert_time(time_stack - t0)
                     )
-                    print(
+                    logger.info(
                         "- Build_samples         :\t"
                         + utils.convert_time(time_samples - time_stack)
                     )
-                    print(
+                    logger.info(
                         "- Random forest (total) :\t"
                         + utils.convert_time(time_random_forest - time_samples)
                     )
-                    print("***")
+                    logger.info("***")
 
             if args.nb_valid_built_pixels == nb_valid_pixels:
                 # Corner case : no "non building pixels"
-                print(
+                logger.info(
                     f"**** Only urban areas in {args.file_vhr} -> mask saved as {args.urbanmask} ****"
                 )
 
@@ -606,7 +609,7 @@ def main():
 
             else:
                 # Corner case : no "building pixels" --> void mask (0)
-                print(
+                logger.info(
                     f"**** No urban areas in {args.file_vhr} -> void mask saved as {args.urbanmask} ****"
                 )
 
@@ -626,19 +629,19 @@ def main():
                 )
 
         except FileNotFoundError as fnfe_exception:
-            print("FileNotFoundError", fnfe_exception)
+            logger.error("FileNotFoundError", fnfe_exception)
 
         except PermissionError as pe_exception:
-            print("PermissionError", pe_exception)
+            logger.error("PermissionError", pe_exception)
 
         except ArithmeticError as ae_exception:
-            print("ArithmeticError", ae_exception)
+            logger.error("ArithmeticError", ae_exception)
 
         except MemoryError as me_exception:
-            print("MemoryError", me_exception)
+            logger.error("MemoryError", me_exception)
 
         except Exception as exception:  # pylint: disable=broad-except
-            print("oups...", exception)
+            logger.error("oups...", exception)
             traceback.print_exc()
 
 

--- a/slurp/masks/urbanmask.py
+++ b/slurp/masks/urbanmask.py
@@ -25,6 +25,7 @@ import gc
 import time
 import traceback
 import logging
+import pathlib
 from os import makedirs, path
 
 import eoscale.eo_executors as eoexe
@@ -254,6 +255,11 @@ def getarguments():
     parser.add_argument(
         "main_config", help="First JSON file, load basis arguments"
     )
+    parser.add_argument("-log_f",
+                        "--logs_to_file",
+                        action="store_true",
+                        help="Store all logs to a file, instead of stdout",
+                        )
 
     group1 = parser.add_argument_group(description="*** INPUT FILES ***")
     group1.add_argument(
@@ -379,9 +385,16 @@ def main():
         if argparse_dict[key] is not None:
             argsdict[key] = argparse_dict[key]
 
+    args = argparse.Namespace(**argsdict)
+
+    if args.logs_to_file:
+        config_file = pathlib.Path("logs/out2stdout.json")
+    else:
+        config_file = pathlib.Path("logs/out2json.json")
+    utils.setup_logging(config_file)
+
     logger.info("JSON data loaded:")
     logger.info(argsdict)
-    args = argparse.Namespace(**argsdict)
 
     # Create output folder
     makedirs(path.dirname(args.urbanmask), exist_ok=True)

--- a/slurp/masks/vegetationmask.py
+++ b/slurp/masks/vegetationmask.py
@@ -24,6 +24,7 @@
 import argparse
 import time
 import traceback
+import logging
 from math import ceil, sqrt
 from os import makedirs, path
 
@@ -41,6 +42,8 @@ from slurp.post_process.morphology import apply_morpho
 from slurp.tools import eoscale_utils as eo_utils
 from slurp.tools import io_utils, utils
 from slurp.tools.constant import NB_CLUSTERS, NODATA_INT8, NODATA_INT16
+
+logger = logging.getLogger("slurp")
 
 NO_VEG_CODE = 0  # Water, other non vegetated areas
 UNDEFINED_VEG = 10  # Non vegetated or few vegetation (weak NDVI signal)
@@ -234,7 +237,7 @@ def apply_clustering(
     """
     # Note : the seed for random generator is fixed to obtain reproductible results
     if params["debug"]:
-        print(f"K-Means on radiometric indices ({nb_polys} elements")
+        logger.debug(f"K-Means on radiometric indices ({nb_polys} elements")
 
     kmeans_rad_indices = KMeans(
         n_clusters=NB_CLUSTERS,
@@ -247,7 +250,7 @@ def apply_clustering(
         np.stack((stats[0:nb_polys], stats[nb_polys : 2 * nb_polys]), axis=1)
     )
     if params["debug"]:
-        print(f"{np.sort(kmeans_rad_indices.cluster_centers_,axis=0)=}")
+        logger.debug(f"{np.sort(kmeans_rad_indices.cluster_centers_,axis=0)=}")
 
     list_clusters = pd.DataFrame.from_records(
         kmeans_rad_indices.cluster_centers_, columns=["ndvi", "ndwi"]
@@ -327,7 +330,7 @@ def apply_clustering(
         )
         threshold_max = np.percentile(texture_values, params["filter_texture"])
         if params["debug"]:
-            print("threshold_texture_max", threshold_max)
+            logger.debug("threshold_texture_max", threshold_max)
 
         # Save histograms
         if params["texture_mode"] == "debug" or params["save_mode"] == "debug":
@@ -354,7 +357,7 @@ def apply_clustering(
         data_textures = np.transpose(texture_values)
         data_textures[data_textures > threshold_max] = threshold_max
         if params["debug"]:
-            print(
+            logger.debug(
                 "K-Means on texture : " + str(len(data_textures)) + " elements"
             )
 
@@ -368,7 +371,7 @@ def apply_clustering(
         pred_texture = kmeans_texture.fit_predict(data_textures.reshape(-1, 1))
 
         if params["debug"]:
-            print(f"{np.sort(kmeans_texture.cluster_centers_,axis=0)=}")
+            logger.debug(f"{np.sort(kmeans_texture.cluster_centers_,axis=0)=}")
 
         list_clusters = pd.DataFrame.from_records(
             kmeans_texture.cluster_centers_, columns=["mean_texture"]
@@ -669,8 +672,8 @@ def main():
         if argparse_dict[key] is not None:
             argsdict[key] = argparse_dict[key]
 
-    print("JSON data loaded:")
-    print(argsdict)
+    logger.info("JSON data loaded:")
+    logger.info(argsdict)
     args = argparse.Namespace(**argsdict)
 
     # Create output folder
@@ -736,7 +739,7 @@ def main():
             # Recover number total of segments
             nb_polys = np.max(eoscale_manager.get_array(future_seg[0])[0])
             if args.debug:
-                print(
+                logger.debug(
                     "Number of different segments detected : " + str(nb_polys)
                 )
 
@@ -830,57 +833,57 @@ def main():
             )
             end_time = time.time()
 
-            print(
+            logger.info(
                 f"**** Vegetation mask for {args.file_vhr} (saved as {args.vegetationmask}) ****"
             )
-            print(
+            logger.info(
                 "Total time (user)       :\t"
                 + utils.convert_time(end_time - t0)
             )
-            print(
+            logger.info(
                 "- Build_stack           :\t"
                 + utils.convert_time(time_stack - t0)
             )
-            print(
+            logger.info(
                 "- Segmentation          :\t"
                 + utils.convert_time(time_seg - time_stack)
             )
-            print(
+            logger.info(
                 "- Stats                 :\t"
                 + utils.convert_time(time_stats - time_seg)
             )
-            print(
+            logger.info(
                 "- Clustering            :\t"
                 + utils.convert_time(time_cluster - time_stats)
             )
-            print(
+            logger.info(
                 "- Finalize Cython       :\t"
                 + utils.convert_time(time_final - time_cluster)
             )
-            print(
+            logger.info(
                 "- Post-processing       :\t"
                 + utils.convert_time(time_closing - time_final)
             )
-            print(
+            logger.info(
                 "- Write final image     :\t"
                 + utils.convert_time(end_time - time_closing)
             )
-            print("***")
+            logger.info("***")
 
         except FileNotFoundError as fnfe_exception:
-            print("FileNotFoundError", fnfe_exception)
+            logger.error("FileNotFoundError", fnfe_exception)
 
         except PermissionError as pe_exception:
-            print("PermissionError", pe_exception)
+            logger.error("PermissionError", pe_exception)
 
         except ArithmeticError as ae_exception:
-            print("ArithmeticError", ae_exception)
+            logger.error("ArithmeticError", ae_exception)
 
         except MemoryError as me_exception:
-            print("MemoryError", me_exception)
+            logger.error("MemoryError", me_exception)
 
         except Exception as exception:  # pylint: disable=broad-except
-            print("oups...", exception)
+            logger.error("oups...", exception)
             traceback.print_exc()
 
 

--- a/slurp/masks/vegetationmask.py
+++ b/slurp/masks/vegetationmask.py
@@ -680,13 +680,13 @@ def main():
 
     args = argparse.Namespace(**argsdict)
 
-    print(getcwd())
     if args.logs_to_file:
-        config_file = pathlib.Path("slurp/tools/logs/out2stdout.json")
-    else:
         config_file = pathlib.Path("slurp/tools/logs/out2json.json")
+        if not path.exists("logs"):
+            makedirs("logs")
+    else:
+        config_file = pathlib.Path("slurp/tools/logs/out2stdout.json")
     utils.setup_logging(config_file)
-
     logger.info("JSON data loaded:")
     logger.info(argsdict)
 

--- a/slurp/masks/vegetationmask.py
+++ b/slurp/masks/vegetationmask.py
@@ -27,7 +27,7 @@ import traceback
 import logging
 import pathlib
 from math import ceil, sqrt
-from os import makedirs, path
+from os import makedirs, path, getcwd
 
 import eoscale.eo_executors as eoexe
 import eoscale.manager as eom
@@ -680,10 +680,11 @@ def main():
 
     args = argparse.Namespace(**argsdict)
 
+    print(getcwd())
     if args.logs_to_file:
-        config_file = pathlib.Path("logs/out2stdout.json")
+        config_file = pathlib.Path("slurp/tools/logs/out2stdout.json")
     else:
-        config_file = pathlib.Path("logs/out2json.json")
+        config_file = pathlib.Path("slurp/tools/logs/out2json.json")
     utils.setup_logging(config_file)
 
     logger.info("JSON data loaded:")

--- a/slurp/masks/vegetationmask.py
+++ b/slurp/masks/vegetationmask.py
@@ -25,6 +25,7 @@ import argparse
 import time
 import traceback
 import logging
+import pathlib
 from math import ceil, sqrt
 from os import makedirs, path
 
@@ -534,6 +535,11 @@ def getarguments():
     parser.add_argument(
         "main_config", help="First JSON file, load basis arguments"
     )
+    parser.add_argument("-log_f",
+                        "--logs_to_file",
+                        action="store_true",
+                        help="Store all logs to a file, instead of stdout",
+                        )
 
     parser.add_argument("-d", "--debug", action="store_true", help="Debug flag")
 
@@ -672,9 +678,16 @@ def main():
         if argparse_dict[key] is not None:
             argsdict[key] = argparse_dict[key]
 
+    args = argparse.Namespace(**argsdict)
+
+    if args.logs_to_file:
+        config_file = pathlib.Path("logs/out2stdout.json")
+    else:
+        config_file = pathlib.Path("logs/out2json.json")
+    utils.setup_logging(config_file)
+
     logger.info("JSON data loaded:")
     logger.info(argsdict)
-    args = argparse.Namespace(**argsdict)
 
     # Create output folder
     makedirs(path.dirname(args.vegetationmask), exist_ok=True)

--- a/slurp/masks/watermask.py
+++ b/slurp/masks/watermask.py
@@ -617,9 +617,11 @@ def main():
     args = argparse.Namespace(**argsdict)
 
     if args.logs_to_file:
-        config_file = pathlib.Path("logs/out2stdout.json")
+        config_file = pathlib.Path("slurp/tools/logs/out2json.json")
+        if not path.exists("logs"):
+            makedirs("logs")
     else:
-        config_file = pathlib.Path("logs/out2json.json")
+        config_file = pathlib.Path("slurp/tools/logs/out2stdout.json")
     utils.setup_logging(config_file)
 
     logger.info("JSON data loaded:")
@@ -814,7 +816,7 @@ def main():
                     n_jobs=1,
                 )
                 logger.info(
-                    "RandomForest parameters:\n", classifier.get_params(), "\n"
+                    "RandomForest parameters: \n%s\n", str(classifier.get_params())
                 )
                 samples = np.concatenate(samples[:])  # A revoir si possible
                 x_samples = samples[

--- a/slurp/masks/watermask.py
+++ b/slurp/masks/watermask.py
@@ -26,6 +26,7 @@ import gc
 import time
 import traceback
 import logging
+import pathlib
 from os import makedirs, path
 from typing import get_args
 
@@ -416,6 +417,11 @@ def getarguments():
     parser.add_argument(
         "-d", "--debug", action="store_true", dest="debug", help="Debug flag"
     )
+    parser.add_argument("-log_f",
+                        "--logs_to_file",
+                        action="store_true",
+                        help="Store all logs to a file, instead of stdout",
+                        )
 
     group1 = parser.add_argument_group(description="*** INPUT FILES ***")
     group1.add_argument(
@@ -608,9 +614,16 @@ def main():
         if argparse_dict[key] is not None:
             argsdict[key] = argparse_dict[key]
 
+    args = argparse.Namespace(**argsdict)
+
+    if args.logs_to_file:
+        config_file = pathlib.Path("logs/out2stdout.json")
+    else:
+        config_file = pathlib.Path("logs/out2json.json")
+    utils.setup_logging(config_file)
+
     logger.info("JSON data loaded:")
     logger.info(argsdict)
-    args = argparse.Namespace(**argsdict)
 
     # Create output folder
     makedirs(path.dirname(args.watermask), exist_ok=True)

--- a/slurp/masks/watermask.py
+++ b/slurp/masks/watermask.py
@@ -25,7 +25,9 @@ import argparse
 import gc
 import time
 import traceback
+import logging
 from os import makedirs, path
+from typing import get_args
 
 import eoscale.eo_executors as eoexe
 import eoscale.manager as eom
@@ -39,12 +41,14 @@ from slurp.tools import eoscale_utils as eo_utils
 from slurp.tools import io_utils, utils
 from slurp.tools.constant import NODATA_INT8
 
+logger = logging.getLogger("slurp")
+
 try:
     from sklearnex import patch_sklearn
 
     patch_sklearn()
 except ModuleNotFoundError:
-    print("Intel(R) Extension/Optimization for scikit-learn not found.")
+    logger.error("Intel(R) Extension/Optimization for scikit-learn not found.")
 
 
 def compute_pekel_mask(
@@ -357,7 +361,7 @@ def post_process(
         if not params["hand_strict"]:
             input_buffer[0][np.logical_not(input_buffer[1])] = 0
         else:
-            print("\nWARNING: hand_filter and hand_strict are incompatible.")
+            logger.warning("\nWARNING: hand_filter and hand_strict are incompatible.")
 
     # Filter for final classification
     if not params["no_pekel_filter"]:
@@ -604,8 +608,8 @@ def main():
         if argparse_dict[key] is not None:
             argsdict[key] = argparse_dict[key]
 
-    print("JSON data loaded:")
-    print(argsdict)
+    logger.info("JSON data loaded:")
+    logger.info(argsdict)
     args = argparse.Namespace(**argsdict)
 
     # Create output folder
@@ -627,7 +631,6 @@ def main():
             # Image PHR (numpy array, 4 bands, band number is first dimension),
             key_phr = eoscale_manager.open_raster(raster_path=args.file_vhr)
             profile_phr = eoscale_manager.get_profile(key_phr)
-            eo_utils.print_dataset_infos(args.file_vhr, profile_phr, "PHR")
 
             args.nodata_phr = profile_phr["nodata"]
             args.shape = (profile_phr["height"], profile_phr["width"])
@@ -657,9 +660,6 @@ def main():
                 raster_path=args.extracted_pekel
             )
             pekel_profile = eoscale_manager.get_profile(key_pekel)
-            eo_utils.print_dataset_infos(
-                args.extracted_pekel, pekel_profile, "PEKEL"
-            )
             args.pekel_nodata = pekel_profile["nodata"]
 
             # Pekel valid masks
@@ -686,7 +686,7 @@ def main():
                 # In case they are too few Pekel pixels, we prefer to threshold NDWI and skip samples selection
                 # Alternative would be to select samples in a thresholded NDWI...
                 not_enough_water_samples = True
-                print(
+                logger.warning(
                     "** WARNING ** not enough water samples are found in Pekel : return a void mask"
                 )
 
@@ -695,9 +695,6 @@ def main():
                 raster_path=args.extracted_hand
             )
             hand_profile = eoscale_manager.get_profile(key_hand)
-            eo_utils.print_dataset_infos(
-                args.extracted_hand, hand_profile, "HAND"
-            )
             args.hand_nodata = hand_profile["nodata"]
 
             # Create HAND mask
@@ -718,7 +715,7 @@ def main():
 
             if args.simple_ndwi_threshold:
                 # Simple NDWI threshold, but taking account valid stack to take care of NO_DATA values
-                print(
+                logger.info(
                     "Simple threshold mask NDWI > " + str(args.ndwi_threshold)
                 )
                 key_predict = eoexe.n_images_to_m_images_filter(
@@ -803,7 +800,7 @@ def main():
                     random_state=712,
                     n_jobs=1,
                 )
-                print(
+                logger.info(
                     "RandomForest parameters:\n", classifier.get_params(), "\n"
                 )
                 samples = np.concatenate(samples[:])  # A revoir si possible
@@ -877,47 +874,47 @@ def main():
             utils.display_mem_usage(args.debug, "End of computation")
             end_time = time.time()
 
-            print(
+            logger.info(
                 f"**** Water mask for {args.file_vhr} (saved as {args.watermask}) ****"
             )
-            print(
+            logger.info(
                 "Total time (user)       :\t"
                 + utils.convert_time(end_time - t0)
             )
-            print(
+            logger.info(
                 "- Build_stack           :\t"
                 + utils.convert_time(time_stack - t0)
             )
             if not args.simple_ndwi_threshold and not not_enough_water_samples:
-                print(
+                logger.info(
                     "- Build_samples         :\t"
                     + utils.convert_time(time_samples - time_stack)
                 )
-                print(
+                logger.info(
                     "- Random forest (total) :\t"
                     + utils.convert_time(time_random_forest - time_samples)
                 )
-                print(
+                logger.info(
                     "- Post-processing       :\t"
                     + utils.convert_time(end_time - time_random_forest)
                 )
-            print("***")
-            print("Max workers used for parallel tasks " + str(args.n_workers))
+            logger.info("***")
+            logger.info("Max workers used for parallel tasks " + str(args.n_workers))
 
         except FileNotFoundError as fnfe_exception:
-            print("FileNotFoundError", fnfe_exception)
+            logger.error("FileNotFoundError", fnfe_exception)
 
         except PermissionError as pe_exception:
-            print("PermissionError", pe_exception)
+            logger.error("PermissionError", pe_exception)
 
         except ArithmeticError as ae_exception:
-            print("ArithmeticError", ae_exception)
+            logger.error("ArithmeticError", ae_exception)
 
         except MemoryError as me_exception:
-            print("MemoryError", me_exception)
+            logger.error("MemoryError", me_exception)
 
         except Exception as exception:  # pylint: disable=broad-except
-            print("oups...", exception)
+            logger.error("oups...", exception)
             traceback.print_exc()
 
 

--- a/slurp/post_process/morphology.py
+++ b/slurp/post_process/morphology.py
@@ -22,6 +22,7 @@
 """Brings together the morphology functions"""
 
 import numpy as np
+import logging
 from skimage.morphology import (
     area_closing,
     binary_closing,
@@ -33,6 +34,7 @@ from skimage.morphology import (
     remove_small_objects,
 )
 
+logger = logging.getLogger("slurp")
 
 def apply_morpho(input_array: np.ndarray, key: str, value: int) -> np.ndarray:
     """

--- a/slurp/prepare/analyse_glcm.py
+++ b/slurp/prepare/analyse_glcm.py
@@ -23,10 +23,12 @@ Use a global land cover map to calculate the better number of vegetation cluster
 """
 
 import numpy as np
+import logging
 import rasterio as rio
 
 from slurp.prepare import geometry
 
+logger = logging.getLogger("slurp")
 
 def get_advices(veg, low_veg, high_veg, nb_total):
     """
@@ -92,7 +94,7 @@ def compute_stats(
     if not cropped:
         # get ROI before computing stats
         if sensor_mode:
-            print(
+            logger.error(
                 "ERROR : GLCM analysis not implemented for sensor mode yet. Returns default clustering values"
             )
             return 3, 3
@@ -104,7 +106,7 @@ def compute_stats(
         ds.close()
         del ds
 
-    print(f"{data_map.shape}")
+    logger.info(f"{data_map.shape}")
 
     width = data_map.shape[0]
     height = data_map.shape[1]
@@ -117,7 +119,7 @@ def compute_stats(
     low_vegetation_classes = [20, 30, 40, 90, 100]
     high_vegetation_classes = [10, 95]
     for v, c in zip(unique, counts):
-        print(f"{v} : {c}")
+        logger.info(f"{v} : {c}")
         if v in vegetation_classes:
             veg += c
 
@@ -131,11 +133,11 @@ def compute_stats(
         veg, low_veg, high_veg, nb_total
     )
 
-    print(f"Vegetation (% area) \t: {100*veg/nb_total:.2f}%")
-    print(f"Low vegetation (% area) \t: {100*low_veg/nb_total:.2f}%")
-    print(f"High vegetation (% area) \t: {100*high_veg/nb_total:.2f}%")
+    logger.info(f"Vegetation (% area) \t: {100*veg/nb_total:.2f}%")
+    logger.info(f"Low vegetation (% area) \t: {100*low_veg/nb_total:.2f}%")
+    logger.info(f"High vegetation (% area) \t: {100*high_veg/nb_total:.2f}%")
 
-    print(f"export VEG_CLUSTERS={nb_clusters_veg}")
-    print(f"export LOW_VEG_CLUSTERS={nb_clusters_low_veg}")
+    logger.info(f"export VEG_CLUSTERS={nb_clusters_veg}")
+    logger.info(f"export LOW_VEG_CLUSTERS={nb_clusters_low_veg}")
 
     return nb_clusters_veg, nb_clusters_low_veg

--- a/slurp/prepare/aux_files.py
+++ b/slurp/prepare/aux_files.py
@@ -23,10 +23,12 @@
 
 import numpy as np
 import scipy
+import logging
 
 from slurp.prepare import geometry
 from slurp.tools.constant import NODATA_INT16
 
+logger = logging.getLogger("slurp")
 
 def aux_file_recovery(
     file_ref: str,
@@ -49,7 +51,7 @@ def aux_file_recovery(
     :param bool sensor_mode: true if file_ref is in sensor mode (not georeferenced)
     :returns: global data cropped onto target image geometry
     """
-    print(
+    logger.info(
         f"Recover file {global_data=} to {reprojected_data=} onto {file_ref=} geometry"
     )
     if sensor_mode:

--- a/slurp/prepare/geometry.py
+++ b/slurp/prepare/geometry.py
@@ -27,6 +27,7 @@ import time
 
 import bindings_cpp
 import numpy as np
+import logging
 import rasterio as rio
 from shareloc.dtm_reader import dtm_reader
 from shareloc.geofunctions.localization import Localization
@@ -35,6 +36,7 @@ from shareloc.image import Image
 
 from slurp.tools.constant import COMPRESSION
 
+logger = logging.getLogger("slurp")
 
 def superimpose(file_in: str, file_ref: str, file_out: str):
     """
@@ -72,7 +74,7 @@ def superimpose(file_in: str, file_ref: str, file_out: str):
     app.SetParameterOutputImagePixelType("out", output_dtype)
     app.ExecuteAndWriteOutput()
 
-    print("Superimpose in", time.time() - start_time, "seconds.")
+    logger.info("Superimpose in", time.time() - start_time, "seconds.")
 
 
 def rasterization(file_in: str, file_ref: str, file_out: str):
@@ -114,7 +116,7 @@ def rasterization(file_in: str, file_ref: str, file_out: str):
 
     app.ExecuteAndWriteOutput()
 
-    print("Rasterize in", time.time() - start_time, "seconds.")
+    logger.info("Rasterize in", time.time() - start_time, "seconds.")
 
 
 def get_extract_roi(file_in: str, file_ref: str) -> np.ndarray:
@@ -136,7 +138,7 @@ def get_extract_roi(file_in: str, file_ref: str) -> np.ndarray:
     app_roi.SetParameterString("out", "fake.tif")
     app_roi.Execute()
 
-    print("Extract ROI in", time.time() - start_time, "seconds.")
+    logger.info("Extract ROI in", time.time() - start_time, "seconds.")
 
     return app_roi.GetVectorImageAsNumpyArray("out")
 

--- a/slurp/prepare/prepare.py
+++ b/slurp/prepare/prepare.py
@@ -27,7 +27,7 @@ import json
 import time
 import traceback
 import pathlib
-from os import makedirs, path, getcwd
+from os import makedirs, path
 from typing import List
 import logging
 
@@ -41,7 +41,7 @@ from slurp.prepare import geometry, primitives, validity
 from slurp.tools import eoscale_utils as eo_utils
 from slurp.tools import io_utils, utils
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("slurp")
 
 def getarguments():
     """Parse command line arguments."""
@@ -573,14 +573,16 @@ def main():
     argsdict = read_and_overload_arguments(vars(getarguments()))
     args = argparse.Namespace(**argsdict)
 
-    print(getcwd())
     if args.logs_to_file:
-
-        config_file = pathlib.Path("logs/out2stdout.json")
+        config_file = pathlib.Path("slurp/tools/logs/out2json.json")
+        if not path.exists("logs"):
+            makedirs("logs")
     else:
-        config_file = pathlib.Path("logs/out2json.json")
+        config_file = pathlib.Path("slurp/tools/logs/out2stdout.json")
     utils.setup_logging(config_file)
 
+    logger.info("--"*50)
+    logger.info("SLURP_PREPARE")
     logger.info("JSON data loaded:")
     logger.info(argsdict)
 

--- a/slurp/prepare/prepare.py
+++ b/slurp/prepare/prepare.py
@@ -28,6 +28,7 @@ import time
 import traceback
 from os import makedirs, path
 from typing import List
+import logging
 
 import eoscale.eo_executors as eoexe
 import eoscale.manager as eom
@@ -39,6 +40,7 @@ from slurp.prepare import geometry, primitives, validity
 from slurp.tools import eoscale_utils as eo_utils
 from slurp.tools import io_utils, utils
 
+logger = logging.getLogger(__name__)
 
 def getarguments():
     """Parse command line arguments."""
@@ -405,9 +407,9 @@ def pekel_extraction(
                     "Method for Pekel extraction not accepted. Use 'month' or 'all'"
                 )
         else:
-            print("Not extracting Pekel : the file already exists.")
+            logger.info("Not extracting Pekel : the file already exists.")
     else:
-        print("Pass Pekel extraction")
+        logger.info("Pass Pekel extraction")
 
 
 def hand_extraction(
@@ -440,9 +442,9 @@ def hand_extraction(
                 roi,
             )
         else:
-            print("Not extracting Hand : the file already exists.")
+            logger.info("Not extracting Hand : the file already exists.")
     else:
-        print("Pass Hand extraction")
+        logger.info("Pass Hand extraction")
 
 
 def wsf_extraction(
@@ -476,9 +478,9 @@ def wsf_extraction(
                 roi,
             )
         else:
-            print("Not extracting WSF : the file already exists.")
+            logger.info("Not extracting WSF : the file already exists.")
     else:
-        print("Pass WSF extraction")
+        logger.info("Pass WSF extraction")
 
 
 def compute_texture(
@@ -525,9 +527,9 @@ def compute_texture(
                 key=key_texture[0], img_path=args.file_texture
             )
         else:
-            print("Not computing texture file : the file already exists.")
+            logger.info("Not computing texture file : the file already exists.")
     else:
-        print("Pass texture computation")
+        logger.info("Pass texture computation")
 
 
 def update_and_save_used_config(args_dict: dict, args: argparse.Namespace):
@@ -562,10 +564,10 @@ def main():
     sensor geometry, geoid and DTM.
 
     """
-
+    utils.setup_logger()
     argsdict = read_and_overload_arguments(vars(getarguments()))
-    print("JSON data loaded:")
-    print(argsdict)
+    logger.info("JSON data loaded:")
+    logger.info(argsdict)
     args = argparse.Namespace(**argsdict)
 
     # Compute prepare data with eoscale
@@ -594,7 +596,7 @@ def main():
                     key=valid_stack_key[0], img_path=args.valid_stack
                 )
             else:
-                print(
+                logger.info(
                     "Not computing valid stack mask : the file already exists."
                 )
                 valid_stack_key = [
@@ -608,7 +610,7 @@ def main():
                 )
                 eoscale_manager.write(key=ndvi_key[0], img_path=args.file_ndvi)
             else:
-                print("Not computing NDVI : the file already exists.")
+                logger.info("Not computing NDVI : the file already exists.")
 
             # NDWI
             if args.overwrite or not path.isfile(args.file_ndwi):
@@ -617,7 +619,7 @@ def main():
                 )
                 eoscale_manager.write(key=ndwi_key[0], img_path=args.file_ndwi)
             else:
-                print("Not computing NDWI : the file already exists.")
+                logger.info("Not computing NDWI : the file already exists.")
 
             if args.sensor_mode:
                 grid_sensor, grid_geo, all_coords, roi = (
@@ -649,25 +651,25 @@ def main():
             eoscale_manager._release_all()
 
             t1 = time.time()
-            print("Total time (user)       :\t" + utils.convert_time(t1 - t0))
+            logger.info("Total time (user)       :\t" + utils.convert_time(t1 - t0))
 
         except FileNotFoundError as fnfe_exception:
-            print("FileNotFoundError", fnfe_exception)
+            logger.error("FileNotFoundError", fnfe_exception)
 
         except PermissionError as pe_exception:
-            print("PermissionError", pe_exception)
+            logger.error("PermissionError", pe_exception)
 
         except ArithmeticError as ae_exception:
-            print("ArithmeticError", ae_exception)
+            logger.error("ArithmeticError", ae_exception)
 
         except MemoryError as me_exception:
-            print("MemoryError", me_exception)
+            logger.error("MemoryError", me_exception)
 
         except Exception as exception:
-            print("oups...", exception)
+            logger.error("oups...", exception)
             traceback.print_exc()
 
-    print("End of prepare step")
+    logger.info("End of prepare step")
 
 
 if __name__ == "__main__":

--- a/slurp/prepare/prepare.py
+++ b/slurp/prepare/prepare.py
@@ -27,7 +27,7 @@ import json
 import time
 import traceback
 import pathlib
-from os import makedirs, path
+from os import makedirs, path, getcwd
 from typing import List
 import logging
 
@@ -573,7 +573,9 @@ def main():
     argsdict = read_and_overload_arguments(vars(getarguments()))
     args = argparse.Namespace(**argsdict)
 
+    print(getcwd())
     if args.logs_to_file:
+
         config_file = pathlib.Path("logs/out2stdout.json")
     else:
         config_file = pathlib.Path("logs/out2json.json")

--- a/slurp/prepare/prepare.py
+++ b/slurp/prepare/prepare.py
@@ -26,6 +26,7 @@ import argparse
 import json
 import time
 import traceback
+import pathlib
 from os import makedirs, path
 from typing import List
 import logging
@@ -59,6 +60,11 @@ def getarguments():
         help="Recompute files even if exists",
     )
     parser.add_argument("-effective_used_config", type=str, help="")
+    parser.add_argument("-log_f",
+        "--logs_to_file",
+        action="store_true",
+        help="Store all logs to a file, instead of stdout",
+    )
 
     group1 = parser.add_argument_group(description="*** INPUT FILES ***")
     group1.add_argument(
@@ -564,11 +570,17 @@ def main():
     sensor geometry, geoid and DTM.
 
     """
-    utils.setup_logger()
     argsdict = read_and_overload_arguments(vars(getarguments()))
+    args = argparse.Namespace(**argsdict)
+
+    if args.logs_to_file:
+        config_file = pathlib.Path("logs/out2stdout.json")
+    else:
+        config_file = pathlib.Path("logs/out2json.json")
+    utils.setup_logging(config_file)
+
     logger.info("JSON data loaded:")
     logger.info(argsdict)
-    args = argparse.Namespace(**argsdict)
 
     # Compute prepare data with eoscale
     with eom.EOContextManager(

--- a/slurp/tools/eoscale_utils.py
+++ b/slurp/tools/eoscale_utils.py
@@ -22,32 +22,17 @@
 import copy
 
 import numpy as np
+import logging
 
 from slurp.tools.constant import COMPRESSION, DRIVER, NODATA_INT8, NODATA_INT16
 
-
-def print_dataset_infos(name, profile, prefix=""):
-    """Print information about rasterio dataset."""
-
-    print()
-    print(prefix, "Image name :", name)
-    print(prefix, "Image size :", profile["width"], "x", profile["height"])
-    print(prefix, "Image bands :", profile["count"])
-    print(prefix, "Image types :", profile["dtype"])
-    print(prefix, "Image nodata :", profile["nodata"])
-    print(prefix, "Image crs :", profile["crs"])
-    print(prefix, "Image transform :", profile["transform"])
-    print(prefix, "Image driver :", profile["driver"])
-    print()
+logger = logging.getLogger("slurp")
 
 
 def concatenate_samples(output_scalars, chunk_output_scalars, tile):
     output_scalars.append(chunk_output_scalars[0])
 
-
 # Profiles
-
-
 def single_float_profile(input_profiles: list, map_params):
     """Define profile for eoscale"""
     profile = input_profiles[0]

--- a/slurp/tools/io_utils.py
+++ b/slurp/tools/io_utils.py
@@ -23,10 +23,12 @@ import json
 
 import matplotlib.pyplot as plt
 import numpy as np
+import logging
 import rasterio as rio
 
 from slurp.tools.constant import COMPRESSION, DRIVER
 
+logger = logging.getLogger("slurp")
 
 def read_json(
     main_config_file: str, keys: list, user_config_file: str = None
@@ -48,9 +50,9 @@ def read_json(
                 argsdict.update(full_args[key])
 
     except FileNotFoundError:
-        print(f"File {main_config_file} not found.")
+        logger.error(f"File {main_config_file} not found.")
     except json.JSONDecodeError:
-        print(
+        logger.error(
             f"Error decoding JSON data from {main_config_file}. Please check the file format."
         )
 
@@ -63,27 +65,13 @@ def read_json(
                     argsdict.update(full_args[k])
 
         except FileNotFoundError:
-            print(f"File {user_config_file} not found.")
+            logger.error(f"File {user_config_file} not found.")
         except json.JSONDecodeError:
-            print(
+            logger.error(
                 f"Error decoding JSON data from {user_config_file}. Please check the file format."
             )
 
     return argsdict
-
-
-def print_dataset_infos(dataset, prefix=""):
-    """Print information about rasterio dataset."""
-
-    print()
-    print(prefix, "Image name :", dataset.name)
-    print(prefix, "Image size :", dataset.width, "x", dataset.height)
-    print(prefix, "Image bands :", dataset.count)
-    print(prefix, "Image types :", dataset.dtypes)
-    print(prefix, "Image nodata :", dataset.nodatavals, dataset.nodata)
-    print(prefix, "Image crs :", dataset.crs)
-    print(prefix, "Image bounds :", dataset.bounds)
-    print()
 
 
 def save_image(

--- a/slurp/tools/logs/out2json.json
+++ b/slurp/tools/logs/out2json.json
@@ -1,0 +1,48 @@
+{
+  "version": 1,
+  "disable_existing_loggers": false,
+  "formatters": {
+    "simple": {
+      "format": "%(levelname)s: %(message)s",
+      "datefmt": "%Y-%m-%dT%H:%M:%S%z"
+    },
+    "json": {
+      "()": "mylogger.MyJSONFormatter",
+      "fmt_keys": {
+        "level": "levelname",
+        "message": "message",
+        "timestamp": "timestamp",
+        "logger": "name",
+        "module": "module",
+        "function": "funcName",
+        "line": "lineno",
+        "thread_name": "threadName"
+      }
+    }
+  },
+  "handlers": {
+    "stderr": {
+      "class": "logging.StreamHandler",
+      "level": "WARNING",
+      "formatter": "simple",
+      "stream": "ext://sys.stderr"
+    },
+    "file": {
+      "class": "logging.handlers.RotatingFileHandler",
+      "level": "DEBUG",
+      "formatter": "json",
+      "filename": "logs/my_app.log.jsonl",
+      "maxBytes": 10000,
+      "backupCount": 3
+    }
+  },
+  "loggers": {
+    "root": {
+      "level": "DEBUG",
+      "handlers": [
+        "stderr",
+        "file"
+      ]
+    }
+  }
+}

--- a/slurp/tools/logs/out2json.json
+++ b/slurp/tools/logs/out2json.json
@@ -7,7 +7,7 @@
       "datefmt": "%Y-%m-%dT%H:%M:%S%z"
     },
     "json": {
-      "()": "mylogger.MyJSONFormatter",
+      "()": "slurp.tools.mylogger.MyJSONFormatter",
       "fmt_keys": {
         "level": "levelname",
         "message": "message",

--- a/slurp/tools/logs/out2json.json
+++ b/slurp/tools/logs/out2json.json
@@ -21,26 +21,19 @@
     }
   },
   "handlers": {
-    "stderr": {
-      "class": "logging.StreamHandler",
-      "level": "WARNING",
-      "formatter": "simple",
-      "stream": "ext://sys.stderr"
-    },
     "file": {
       "class": "logging.handlers.RotatingFileHandler",
-      "level": "DEBUG",
-      "formatter": "json",
-      "filename": "logs/my_app.log.jsonl",
+      "level": "INFO",
+      "formatter": "simple",
+      "filename": "logs/out_logs.log",
       "maxBytes": 10000,
       "backupCount": 3
     }
   },
   "loggers": {
-    "root": {
+    "slurp": {
       "level": "DEBUG",
       "handlers": [
-        "stderr",
         "file"
       ]
     }

--- a/slurp/tools/logs/out2stdout.json
+++ b/slurp/tools/logs/out2stdout.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "disable_existing_loggers": false,
+  "formatters": {
+    "simple": {
+      "format": "%(levelname)s: %(message)s"
+    }
+  },
+  "handlers": {
+    "stdout": {
+      "class": "logging.StreamHandler",
+      "formatter": "simple",
+      "stream": "ext://sys.stdout"
+    }
+  },
+  "loggers": {
+    "root": {
+      "level": "DEBUG",
+      "handlers": [
+        "stdout"
+      ]
+    }
+  }
+}

--- a/slurp/tools/logs/out2stdout.json
+++ b/slurp/tools/logs/out2stdout.json
@@ -9,12 +9,13 @@
   "handlers": {
     "stdout": {
       "class": "logging.StreamHandler",
+      "level": "INFO",
       "formatter": "simple",
       "stream": "ext://sys.stdout"
     }
   },
   "loggers": {
-    "root": {
+    "slurp": {
       "level": "DEBUG",
       "handlers": [
         "stdout"

--- a/slurp/tools/misc.py
+++ b/slurp/tools/misc.py
@@ -22,10 +22,12 @@
 """Brings together miscellaneous display functions"""
 import linecache
 import os
+import logging
 import tracemalloc
 
 import psutil
 
+logger = logging.getLogger("slurp")
 
 def display_top(snapshot, key_type="lineno", limit=10):
     """Print a snapshot of momentary used memory"""
@@ -38,26 +40,26 @@ def display_top(snapshot, key_type="lineno", limit=10):
     )
     top_stats = snapshot.statistics(key_type)
 
-    print(f"Top {limit} lines")
+    logger.info(f"Top {limit} lines")
     for index, stat in enumerate(top_stats[:limit], 1):
         frame = stat.traceback[0]
         # replace "/path/to/module/file.py" with "module/file.py"
         filename = os.sep.join(frame.filename.split(os.sep)[-2:])
-        print(
+        logger.info(
             f"#{index}: {filename}:{frame.lineno}: {stat.size / 1024:.1f} KiB"
         )
         line = linecache.getline(frame.filename, frame.lineno).strip()
         if line:
-            print(f"    {line}")
+            logger.info(f"    {line}")
 
     other = top_stats[limit:]
     if other:
         size = sum(stat.size for stat in other)
-        print(f"{len(other)} other: {size / 1024:.1f} KiB")
+        logger.info(f"{len(other)} other: {size / 1024:.1f} KiB")
     total = sum(stat.size for stat in top_stats)
-    print(f"Total allocated size: {total / 1024:.1f} KiB")
+    logger.info(f"Total allocated size: {total / 1024:.1f} KiB")
 
 
 def display_mem(step):
     mem_used = psutil.Process().memory_info().rss / (1024 * 1024)
-    print(">>>" + str(step) + "\t >>> Mem used : \t" + str(mem_used) + " Mb")
+    logger.info(">>>" + str(step) + "\t >>> Mem used : \t" + str(mem_used) + " Mb")

--- a/slurp/tools/mylogger.py
+++ b/slurp/tools/mylogger.py
@@ -1,0 +1,75 @@
+import datetime as dt
+import json
+import logging
+
+LOG_RECORD_BUILTIN_ATTRS = {
+    "args",
+    "asctime",
+    "created",
+    "exc_info",
+    "exc_text",
+    "filename",
+    "funcName",
+    "levelname",
+    "levelno",
+    "lineno",
+    "module",
+    "msecs",
+    "message",
+    "msg",
+    "name",
+    "pathname",
+    "process",
+    "processName",
+    "relativeCreated",
+    "stack_info",
+    "thread",
+    "threadName",
+    "taskName",
+}
+
+
+class MyJSONFormatter(logging.Formatter):
+    def __init__(
+        self,
+        *,
+        fmt_keys: dict[str, str] | None = None,
+    ):
+        super().__init__()
+        self.fmt_keys = fmt_keys if fmt_keys is not None else {}
+
+    def format(self, record: logging.LogRecord) -> str:
+        message = self._prepare_log_dict(record)
+        return json.dumps(message, default=str)
+
+    def _prepare_log_dict(self, record: logging.LogRecord):
+        always_fields = {
+            "message": record.getMessage(),
+            "timestamp": dt.datetime.fromtimestamp(
+                record.created, tz=dt.timezone.utc
+            ).isoformat(),
+        }
+        if record.exc_info is not None:
+            always_fields["exc_info"] = self.formatException(record.exc_info)
+
+        if record.stack_info is not None:
+            always_fields["stack_info"] = self.formatStack(record.stack_info)
+
+        message = {
+            key: msg_val
+            if (msg_val := always_fields.pop(val, None)) is not None
+            else getattr(record, val)
+            for key, val in self.fmt_keys.items()
+        }
+        message.update(always_fields)
+
+        for key, val in record.__dict__.items():
+            if key not in LOG_RECORD_BUILTIN_ATTRS:
+                message[key] = val
+
+        return message
+
+
+class NonErrorFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool | logging.LogRecord:
+        return record.levelno <= logging.INFO

--- a/slurp/tools/mylogger.py
+++ b/slurp/tools/mylogger.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from typing import Union
 import json
 import logging
 
@@ -33,7 +34,7 @@ class MyJSONFormatter(logging.Formatter):
     def __init__(
         self,
         *,
-        fmt_keys: dict[str, str] | None = None,
+        fmt_keys: Union[dict, None] = None,
     ):
         super().__init__()
         self.fmt_keys = fmt_keys if fmt_keys is not None else {}
@@ -71,5 +72,5 @@ class MyJSONFormatter(logging.Formatter):
 
 
 class NonErrorFilter(logging.Filter):
-    def filter(self, record: logging.LogRecord) -> bool | logging.LogRecord:
+    def filter(self, record: logging.LogRecord) -> Union[bool, logging.LogRecord]:
         return record.levelno <= logging.INFO

--- a/slurp/tools/random_forest_utils.py
+++ b/slurp/tools/random_forest_utils.py
@@ -21,11 +21,13 @@
 
 """Useful functions for Random Forest implementation"""
 import time
+import logging
 
 import numpy as np
 from sklearn.metrics import accuracy_score
 from sklearn.model_selection import train_test_split
 
+logger = logging.getLogger("slurp")
 
 def print_feature_importance(classifier, layers):
     """Compute feature importance."""
@@ -38,9 +40,9 @@ def print_feature_importance(classifier, layers):
         [tree.feature_importances_ for tree in classifier.estimators_], axis=0
     )
 
-    print("Feature ranking:")
+    logger.info("Feature ranking:")
     for idx in indices:
-        print(
+        logger.info(
             f" {feature_names[idx]:4s} ({importances[idx]:f}) (std={std[idx]:f})"
         )
 
@@ -52,13 +54,13 @@ def train_classifier(classifier, x_samples, y_samples):
         x_samples, y_samples, test_size=0.2, random_state=42
     )
     classifier.fit(x_train, y_train)
-    print("Train time :", time.time() - start_time)
+    logger.info("Train time :", time.time() - start_time)
 
     # Compute accuracy on train and test sets
     x_train_prediction = classifier.predict(x_train)
     x_test_prediction = classifier.predict(x_test)
 
-    print(
+    logger.info(
         "Accuracy on train set :", accuracy_score(y_train, x_train_prediction)
     )
-    print("Accuracy on test set :", accuracy_score(y_test, x_test_prediction))
+    logger.info("Accuracy on test set :", accuracy_score(y_test, x_test_prediction))

--- a/slurp/tools/random_forest_utils.py
+++ b/slurp/tools/random_forest_utils.py
@@ -54,13 +54,13 @@ def train_classifier(classifier, x_samples, y_samples):
         x_samples, y_samples, test_size=0.2, random_state=42
     )
     classifier.fit(x_train, y_train)
-    logger.info("Train time :", time.time() - start_time)
+    logger.info("Train time : %s", str(time.time() - start_time))
 
     # Compute accuracy on train and test sets
     x_train_prediction = classifier.predict(x_train)
     x_test_prediction = classifier.predict(x_test)
 
     logger.info(
-        "Accuracy on train set :", accuracy_score(y_train, x_train_prediction)
+        "Accuracy on train set : %s", str(accuracy_score(y_train, x_train_prediction))
     )
-    logger.info("Accuracy on test set :", accuracy_score(y_test, x_test_prediction))
+    logger.info("Accuracy on test set : %s", str(accuracy_score(y_test, x_test_prediction)))

--- a/slurp/tools/rasterize_osm.py
+++ b/slurp/tools/rasterize_osm.py
@@ -24,11 +24,14 @@ import argparse
 import os
 import time
 import traceback
+import pathlib
+from os import makedirs, path
 import logging
 
 import otbApplication as otb
 
 from slurp.tools.constant import COMPRESSION
+from slurp.tools import utils
 
 logger = logging.getLogger("slurp")
 
@@ -124,7 +127,17 @@ def main():
     """Main function to rasterize"""
     try:
         arguments = getarguments()
+
+        if arguments.logs_to_file:
+            config_file = pathlib.Path("slurp/tools/logs/out2json.json")
+            if not path.exists("logs"):
+                makedirs("logs")
+        else:
+            config_file = pathlib.Path("slurp/tools/logs/out2stdout.json")
+        utils.setup_logging(config_file)
+
         rasterize(arguments)
+
 
     except FileNotFoundError as fnfe_exception:
         logger.error("FileNotFoundError", fnfe_exception)

--- a/slurp/tools/rasterize_osm.py
+++ b/slurp/tools/rasterize_osm.py
@@ -24,11 +24,13 @@ import argparse
 import os
 import time
 import traceback
+import logging
 
 import otbApplication as otb
 
 from slurp.tools.constant import COMPRESSION
 
+logger = logging.getLogger("slurp")
 
 def rasterize(args):
     """Create a rasterized copy of the image passed in arguments"""
@@ -56,7 +58,7 @@ def rasterize(args):
     if args.dilate > 0:
         app_si.SetParameterString("out", "superimpose")
         app_si.Execute()
-        print("Dilatation of vector data / write final result")
+        logger.info("Dilatation of vector data / write final result")
         app_morpho = otb.Registry.CreateApplication(
             "BinaryMorphologicalOperation"
         )
@@ -76,7 +78,7 @@ def rasterize(args):
         )
         app_morpho.ExecuteAndWriteOutput()
     else:
-        print("Write final result")
+        logger.info("Write final result")
         app_si.SetParameterString(
             "out",
             str(
@@ -88,7 +90,7 @@ def rasterize(args):
 
     os.system("rm tmp_OSM_data.sqlite")
 
-    print("Execution time : " + str(time.time() - start_time))
+    logger.info("Execution time : " + str(time.time() - start_time))
 
 
 def getarguments():
@@ -125,19 +127,19 @@ def main():
         rasterize(arguments)
 
     except FileNotFoundError as fnfe_exception:
-        print("FileNotFoundError", fnfe_exception)
+        logger.error("FileNotFoundError", fnfe_exception)
 
     except PermissionError as pe_exception:
-        print("PermissionError", pe_exception)
+        logger.error("PermissionError", pe_exception)
 
     except ArithmeticError as ae_exception:
-        print("ArithmeticError", ae_exception)
+        logger.error("ArithmeticError", ae_exception)
 
     except MemoryError as me_exception:
-        print("MemoryError", me_exception)
+        logger.error("MemoryError", me_exception)
 
     except Exception as exception:  # pylint: disable=broad-except
-        print("oups...", exception)
+        logger.error("oups...", exception)
         traceback.print_exc()
 
 

--- a/slurp/tools/scores.py
+++ b/slurp/tools/scores.py
@@ -24,6 +24,7 @@
 import argparse
 import time
 import traceback
+import logging
 from os.path import dirname, join
 
 import geopandas as gpd
@@ -43,13 +44,13 @@ from sklearn.metrics import (
 from slurp.tools import io_utils
 from slurp.tools.constant import NODATA_INT8
 
+logger = logging.getLogger("slurp")
 
 def generate_polygons_in_gdf(im, crs, transform):
     """Generate polygons in a geodata-frame"""
     buildings = np.array(list(features.shapes(im, transform=transform)))
     mask = buildings[:, 1] == 1.0
     buildings = buildings[mask]
-    # print(buildings.shape)
     geometry = np.array(
         [shape(buildings[i][0]) for i in range(0, len(buildings))]
     )
@@ -91,7 +92,7 @@ def buildings_count(
 ):
     """Count the number of buildings polygons"""
     start_time = time.time()
-    print("## BUILDINGS ANALYSIS ##")
+    logger.info("## BUILDINGS ANALYSIS ##")
 
     # Generate GeoDataFrame
     gdf_predict = generate_polygons_in_gdf(
@@ -118,7 +119,7 @@ def buildings_count(
     gdf_intersect = gpd.overlay(
         gdf_ref_filtered, gdf_predict, how="intersection", keep_geom_type=True
     )
-    print(
+    logger.info(
         f'Detected buildings : {gdf_intersect["id_1"].nunique()}/{gdf_ref_filtered.shape[0]}'
     )
 
@@ -152,17 +153,17 @@ def buildings_count(
                 > args.thresh_overlay
             ]
         )
-        print(
+        logger.info(
             f"Detected buildings above {args.thresh_overlay}% : {detected_buildings}/{gdf_ref_filtered.shape[0]}"
         )
         df_merged["iou"] = df_merged["area_inter"] / df_merged["area_union"]
         iou_buildings = len(df_merged[100 * df_merged["iou"] > args.thresh_iou])
-        print(
+        logger.info(
             f"Detected buildings with an IoU above {args.thresh_iou}% : {iou_buildings}/{gdf_ref_filtered.shape[0]}"
         )
-        print(f"Mean IoU {df_merged['iou'].mean():.2f}")
+        logger.info(f"Mean IoU {df_merged['iou'].mean():.2f}")
 
-    print("Buildings count execution time :", time.time() - start_time)
+    logger.info("Buildings count execution time :", time.time() - start_time)
 
 
 def get_merged_image(im_ref, im_predict, path_out, crs, transform, rpc):
@@ -179,29 +180,29 @@ def get_merged_image(im_ref, im_predict, path_out, crs, transform, rpc):
         rpc,
     )
 
-    print("Merge execution time : " + str(time.time() - start_time))
+    logger.info("Merge execution time : " + str(time.time() - start_time))
 
 
 def get_score(im_ref, im_predict):
     """Print the different scores computed"""
 
     start_time = time.time()
-    print("## SCORES ##")
+    logger.info("## SCORES ##")
 
-    print(f"Accuracy >>> {accuracy_score(im_ref, im_predict):.2f}")
+    logger.info(f"Accuracy >>> {accuracy_score(im_ref, im_predict):.2f}")
     precision = precision_score(im_ref, im_predict)
-    print(f"Precision >>> {precision:.2f}")
+    logger.info(f"Precision >>> {precision:.2f}")
     recall = recall_score(im_ref, im_predict)
-    print(f"Recall >>> {recall:.2f}")
+    logger.info(f"Recall >>> {recall:.2f}")
     f1 = 2 * precision * recall / (precision + recall)
-    print(f"F1 >>> {f1:.2f}")
+    logger.info(f"F1 >>> {f1:.2f}")
 
-    print(f"Jaccard >>> {jaccard_score(im_ref, im_predict):.2f}")
+    logger.info(f"Jaccard >>> {jaccard_score(im_ref, im_predict):.2f}")
     # print("Log loss >>>", log_loss(im_ref, im_predict))
     # print("Confusion matrix >>>", confusion_matrix(im_ref, im_predict))
     # print("F1 >>>", f1_score(im_ref, im_predict))
 
-    print(
+    logger.info(
         "Scores calculation execution time : " + str(time.time() - start_time)
     )
 
@@ -420,19 +421,19 @@ def main():
         get_score(im_ref_1d, im_predict_1d)
 
     except FileNotFoundError as fnfe_exception:
-        print("FileNotFoundError", fnfe_exception)
+        logger.error("FileNotFoundError", fnfe_exception)
 
     except PermissionError as pe_exception:
-        print("PermissionError", pe_exception)
+        logger.error("PermissionError", pe_exception)
 
     except ArithmeticError as ae_exception:
-        print("ArithmeticError", ae_exception)
+        logger.error("ArithmeticError", ae_exception)
 
     except MemoryError as me_exception:
-        print("MemoryError", me_exception)
+        logger.error("MemoryError", me_exception)
 
     except Exception as exception:  # pylint: disable=broad-except
-        print("oups...", exception)
+        logger.error("oups...", exception)
         traceback.print_exc()
 
 

--- a/slurp/tools/utils.py
+++ b/slurp/tools/utils.py
@@ -23,10 +23,23 @@
 import os
 import time
 
+import logging
 import numpy as np
 import psutil
 
 from slurp.tools.constant import NODATA_INT8
+
+logger = logging.getLogger("slurp")
+
+def setup_logger():
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s [%(levelname)s] %(name)s: %(message)s',
+        handlers=[
+            logging.FileHandler("app.log"),
+            logging.StreamHandler()
+        ]
+    )
 
 
 def convert_time(seconds):
@@ -75,4 +88,4 @@ def display_mem_usage(debug_mode, message):
         memory_use = (
             python_process.memory_info()[0] / 2.0**30
         )  # memory use in GB...I think
-        print(f">> {message} >> Mem usage : {memory_use} Gb")
+        logger.debug(f">> {message} >> Mem usage : {memory_use} Gb")

--- a/slurp/tools/utils.py
+++ b/slurp/tools/utils.py
@@ -21,9 +21,11 @@
 """Brings together some useful functions"""
 
 import os
+import json
 import time
 
-import logging
+
+import logging.config
 import numpy as np
 import psutil
 
@@ -31,15 +33,11 @@ from slurp.tools.constant import NODATA_INT8
 
 logger = logging.getLogger("slurp")
 
-def setup_logger():
-    logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s [%(levelname)s] %(name)s: %(message)s',
-        handlers=[
-            logging.FileHandler("app.log"),
-            logging.StreamHandler()
-        ]
-    )
+def setup_logging(config_file : str):
+    with open(config_file) as f_in:
+        config = json.load(f_in)
+
+    logging.config.dictConfig(config)
 
 
 def convert_time(seconds):

--- a/tests/test_valid/test_valid_shadowmask.py
+++ b/tests/test_valid/test_valid_shadowmask.py
@@ -38,7 +38,7 @@ predict_images = glob.glob(os.path.join(pytest.output_dir + "/shadowmask*.tif"))
 def prepare_shadowmask(file, nb_workers):
     valid_stack = get_output_path(file, "valid_stack", remove=True)
     os.system(
-        f"slurp_prepare {pytest.main_config} -file_vhr {file} -n_workers {nb_workers} -valid {valid_stack}"
+        f"slurp_prepare {pytest.main_config} -file_vhr {file} -n_workers {nb_workers} -valid {valid_stack} -log_f"
     )
     assert os.path.exists(
         valid_stack
@@ -52,7 +52,7 @@ def compute_shadowmask(file, nb_workers, valid_stack=None):
         valid_stack = get_aux_path(file, "valid_stack")
     os.system(
         f"slurp_shadowmask {pytest.main_config} -file_vhr {file} -n_workers {nb_workers} "
-        f"-shadowmask {output_image} -valid {valid_stack}"
+        f"-shadowmask {output_image} -valid {valid_stack} -log_f"
     )
     assert os.path.exists(
         output_image

--- a/tests/test_valid/test_valid_stackmask.py
+++ b/tests/test_valid/test_valid_stackmask.py
@@ -51,7 +51,7 @@ def compute_stackmask(file, nb_workers):
     os.system(
         f"slurp_stackmasks {pytest.main_config} -file_vhr {file} -n_workers {nb_workers} -stackmask {output_image} "
         f"-vegetationmask {vegetationmask} -watermask {watermask} "
-        f"-urbanmask {urbanmask} -shadow {shadowmask} -wsf {wsf} -valid {valid_stack} "
+        f"-urbanmask {urbanmask} -shadow {shadowmask} -wsf {wsf} -valid {valid_stack} -log_f"
     )
 
     assert os.path.exists(

--- a/tests/test_valid/test_valid_urbanmask.py
+++ b/tests/test_valid/test_valid_urbanmask.py
@@ -52,7 +52,7 @@ def prepare_urbanmask(file, nb_workers):
 
     os.system(
         f"slurp_prepare {pytest.main_config} -file_vhr {file} -n_workers {nb_workers} "
-        f"-valid {valid_stack} -file_ndvi {ndvi} -file_ndwi {ndwi} -extracted_wsf {wsf} -wsf {pytest.wsf}"
+        f"-valid {valid_stack} -file_ndvi {ndvi} -file_ndwi {ndwi} -extracted_wsf {wsf} -wsf {pytest.wsf} -log_f"
     )
 
     assert os.path.exists(
@@ -87,7 +87,7 @@ def compute_urbanmask(
 
     os.system(
         f"slurp_urbanmask {pytest.main_config} -file_vhr {file} -n_workers {nb_workers} -urbanmask {output_image} "
-        f"-valid {valid_stack} -ndvi {ndvi} -ndwi {ndwi} -wsf {wsf}"
+        f"-valid {valid_stack} -ndvi {ndvi} -ndwi {ndwi} -wsf {wsf} -log_f"
     )
 
     assert os.path.exists(

--- a/tests/test_valid/test_valid_vegetationmask.py
+++ b/tests/test_valid/test_valid_vegetationmask.py
@@ -43,11 +43,9 @@ def prepare_vegetationmask(file, nb_workers):
     ndwi = get_output_path(file, "ndwi", remove=True)
     texture = get_output_path(file, "texture", remove=True)
 
-    print(f"slurp_prepare {pytest.main_config} -file_vhr {file} -n_workers {nb_workers} "
-        f"-valid {valid_stack} -file_ndvi {ndvi} -file_ndwi {ndwi} -file_texture {texture}")
     os.system(
         f"slurp_prepare {pytest.main_config} -file_vhr {file} -n_workers {nb_workers} "
-        f"-valid {valid_stack} -file_ndvi {ndvi} -file_ndwi {ndwi} -file_texture {texture}"
+        f"-valid {valid_stack} -file_ndvi {ndvi} -file_ndwi {ndwi} -file_texture {texture} -log_f"
     )
 
     assert os.path.exists(
@@ -78,11 +76,9 @@ def compute_vegetationmask(
     if texture is None:
         texture = get_aux_path(file, "texture")
 
-    print(f"slurp_vegetationmask {pytest.main_config} -file_vhr {file} -n_workers {nb_workers} "
-        f"-vegetationmask {output_image} -valid {valid_stack} -ndvi {ndvi} -ndwi {ndwi} -texture {texture}")
     os.system(
         f"slurp_vegetationmask {pytest.main_config} -file_vhr {file} -n_workers {nb_workers} "
-        f"-vegetationmask {output_image} -valid {valid_stack} -ndvi {ndvi} -ndwi {ndwi} -texture {texture}"
+        f"-vegetationmask {output_image} -valid {valid_stack} -ndvi {ndvi} -ndwi {ndwi} -texture {texture} -log_f"
     )
 
     assert os.path.exists(

--- a/tests/test_valid/test_valid_vegetationmask.py
+++ b/tests/test_valid/test_valid_vegetationmask.py
@@ -43,6 +43,8 @@ def prepare_vegetationmask(file, nb_workers):
     ndwi = get_output_path(file, "ndwi", remove=True)
     texture = get_output_path(file, "texture", remove=True)
 
+    print(f"slurp_prepare {pytest.main_config} -file_vhr {file} -n_workers {nb_workers} "
+        f"-valid {valid_stack} -file_ndvi {ndvi} -file_ndwi {ndwi} -file_texture {texture}")
     os.system(
         f"slurp_prepare {pytest.main_config} -file_vhr {file} -n_workers {nb_workers} "
         f"-valid {valid_stack} -file_ndvi {ndvi} -file_ndwi {ndwi} -file_texture {texture}"
@@ -76,6 +78,8 @@ def compute_vegetationmask(
     if texture is None:
         texture = get_aux_path(file, "texture")
 
+    print(f"slurp_vegetationmask {pytest.main_config} -file_vhr {file} -n_workers {nb_workers} "
+        f"-vegetationmask {output_image} -valid {valid_stack} -ndvi {ndvi} -ndwi {ndwi} -texture {texture}")
     os.system(
         f"slurp_vegetationmask {pytest.main_config} -file_vhr {file} -n_workers {nb_workers} "
         f"-vegetationmask {output_image} -valid {valid_stack} -ndvi {ndvi} -ndwi {ndwi} -texture {texture}"

--- a/tests/test_valid/test_valid_watermask.py
+++ b/tests/test_valid/test_valid_watermask.py
@@ -53,7 +53,7 @@ def prepare_watermask(file, nb_workers):
     os.system(
         f"slurp_prepare {pytest.main_config} -file_vhr {file} -n_workers {nb_workers} "
         f"-valid {valid_stack} -file_ndvi {ndvi} -file_ndwi {ndwi} "
-        f"-extracted_pekel {pekel} -extracted_hand {hand} -pekel {pytest.pekel} -hand {pytest.hand}"
+        f"-extracted_pekel {pekel} -extracted_hand {hand} -pekel {pytest.pekel} -hand {pytest.hand} -log_f"
     )
 
     assert os.path.exists(
@@ -97,7 +97,7 @@ def compute_watermask(
 
     os.system(
         f"slurp_watermask {pytest.main_config} -file_vhr {file} -n_workers {nb_workers} "
-        f"-watermask {output_image} -valid {valid_stack} -ndvi {ndvi} -ndwi {ndwi} -pekel {pekel} -hand {hand}"
+        f"-watermask {output_image} -valid {valid_stack} -ndvi {ndvi} -ndwi {ndwi} -pekel {pekel} -hand {hand} -log_f"
     )
 
     assert os.path.exists(


### PR DESCRIPTION
Now it is possible to add the flag `-log_f` or `--logs_to_file` to the CLI to print all the logs in the file `slurp/tools/logs/out_logs.log`. If the option is not provided to the CLI, all the logs will be printed in the terminal.