### PR TITLE
Fix type mismatch 

### DIFF
--- a/slurp/prepare/prepare.py
+++ b/slurp/prepare/prepare.py
@@ -707,9 +707,8 @@ def valid_stack_process(
             "Not computing valid stack mask: file already exists."
         )
 
-        valid_stack_key = [
-            read(args.valid_stack)
-        ]
+        valid_stack_key = read(args.valid_stack)
+
     return valid_stack_key
 
 


### PR DESCRIPTION
I've tested an existing case : my 'valid_stack.tif' existed but I wanted to rewrite ndvi.tif : this failed in compute_ndxi (type mismatch).

