### PR TITLE
Remove eoscale shadow stack

### DIFF
--- a/slurp/eomultiprocessing/utils.py
+++ b/slurp/eomultiprocessing/utils.py
@@ -25,6 +25,7 @@ This module contains some utils function for slurp processing.
 import os
 from collections import namedtuple
 from typing import Any, Dict, Tuple
+from copy import deepcopy
 
 import numpy as np
 import rasterio
@@ -106,3 +107,46 @@ def read_window(img_path: str, tile: MpTile) -> np.ndarray:
             data = src.read(1, window=Window(col_off, row_off, tile.width_margin, tile.height_margin))
 
     return data
+
+def create_image(
+    profile: Dict[str, Any],
+    fill_value: Any = 0,
+) -> Tuple[np.ndarray, Dict[str, Any]]:
+    """
+    Create an empty image ndarray from an existing raster profile.
+
+    The returned profile is identical (deep copy) to the input profile.
+
+    Parameters
+    ----------
+    profile : dict
+        Rasterio profile used as template.
+    fill_value : Any, optional
+        Initial value used to fill the image (default: 0).
+
+    Returns
+    -------
+    Tuple[np.ndarray, dict]
+        (image_array, copied_profile)
+
+    Notes
+    -----
+    - Shape follows rasterio convention: (count, height, width)
+    - dtype strictly follows profile["dtype"]
+    """
+
+    new_profile = deepcopy(profile)
+
+    height = new_profile["height"]
+    width = new_profile["width"]
+    count = new_profile.get("count", 1)
+    dtype = np.dtype(new_profile["dtype"])
+
+    # Create ndarray
+    image = np.full(
+        (count, height, width),
+        fill_value,
+        dtype=dtype,
+    )
+
+    return image, new_profile

--- a/slurp/masks/shadowmask.py
+++ b/slurp/masks/shadowmask.py
@@ -31,8 +31,6 @@ import traceback
 from os import path
 from copy import deepcopy
 
-import eoscale.eo_executors as eoexe
-import eoscale.manager as eom
 import numpy as np
 
 from slurp.eomultiprocessing.slurp_executor import mp_n_to_m_images, mp_n_to_m_scalars

--- a/slurp/masks/shadowmask.py
+++ b/slurp/masks/shadowmask.py
@@ -179,6 +179,11 @@ def build_stack_shadow(args, slurp_manager):
     """
     Prepare inputs for shadow mask processing.
 
+    Parameters
+    ----------
+    slurp_manager : object
+        SLURP manager instance (unused but kept for interface consistency).
+
     Returns
     -------
     phr : list

--- a/slurp/masks/shadowmask.py
+++ b/slurp/masks/shadowmask.py
@@ -45,10 +45,10 @@ logger = logging.getLogger("slurp")
 
 
 def compute_thresholds(
-    absolute_threshold, local_phr, nodata, percentile, th_rgb, th_nir
+    absolute_threshold, local_vhr, nodata, percentile, th_rgb, th_nir
 ):
     """
-    Compute thresholds for each band in the provided PHR image.
+    Compute thresholds for each band in the provided VHR image.
     If `absolute_threshold` is provided, the function will use the
     specified value as the threshold for all bands. If not, it calculates thresholds based on the
     specified percentile for each band, with different thresholds for RGB bands and NIR band.
@@ -58,22 +58,22 @@ def compute_thresholds(
         th_bands = np.zeros(4)
         for cpt in range(3):
             min_band = np.percentile(
-                local_phr[cpt][np.where(local_phr[cpt] != nodata)],
+                local_vhr[cpt][np.where(local_vhr[cpt] != nodata)],
                 percentile,
             )
             max_percentile = np.percentile(
-                local_phr[cpt][np.where(local_phr[cpt] != nodata)],
+                local_vhr[cpt][np.where(local_vhr[cpt] != nodata)],
                 100 - percentile,
             )
             th_bands[cpt] = min_band + th_rgb * (max_percentile - min_band)
 
         cpt = 3
         min_band = np.percentile(
-            local_phr[cpt][np.where(local_phr[cpt] != nodata)],
+            local_vhr[cpt][np.where(local_vhr[cpt] != nodata)],
             percentile,
         )
         max_percentile = np.percentile(
-            local_phr[cpt][np.where(local_phr[cpt] != nodata)],
+            local_vhr[cpt][np.where(local_vhr[cpt] != nodata)],
             100 - percentile,
         )
         th_bands[cpt] = min_band + th_nir * (max_percentile - min_band)
@@ -87,10 +87,10 @@ def compute_thresholds(
 
 
 def compute_shadowmask(
-    phr1: np.ndarray,
-    phr2: np.ndarray,
-    phr3: np.ndarray,
-    phr4: np.ndarray,
+    vhr1: np.ndarray,
+    vhr2: np.ndarray,
+    vhr3: np.ndarray,
+    vhr4: np.ndarray,
     valid_stack: np.ndarray,
     watermask: np.ndarray,
     thresholds: list,
@@ -102,7 +102,7 @@ def compute_shadowmask(
 
     Parameters
     ----------
-    phr1, phr2, phr3, phr4 : np.ndarray
+    vhr1, vhr2, vhr3, vhr4 : np.ndarray
         Spectral bands.
     valid_stack : np.ndarray
         Validity mask.
@@ -124,10 +124,10 @@ def compute_shadowmask(
     # ------------------------------
 
     raw_shadow_mask = (
-        (phr1 < thresholds[0])
-        & (phr2 < thresholds[1])
-        & (phr3 < thresholds[2])
-        & (phr4 < thresholds[3])
+        (vhr1 < thresholds[0])
+        & (vhr2 < thresholds[1])
+        & (vhr3 < thresholds[2])
+        & (vhr4 < thresholds[3])
     )
 
     # Remove water shadows
@@ -186,25 +186,25 @@ def build_stack_shadow(args, slurp_manager):
 
     Returns
     -------
-    phr : list
+    vhr : list
     valid_stack : list
     watermask : list
     margin : int
-    phr_profile : dict
+    vhr_profile : dict
     """
 
     logger.info("Loading base rasters")
 
     # ==============================
-    # PHR
+    # VHR
     # ==============================
 
-    key_phr, phr_profile = read_and_get_profile(args.file_vhr)
+    key_vhr, vhr_profile = read_and_get_profile(args.file_vhr)
 
-    args.nodata_phr = phr_profile.get("nodata")
-    args.shape = (phr_profile["height"], phr_profile["width"])
-    args.crs = phr_profile["crs"]
-    args.transform = phr_profile["transform"]
+    args.nodata_vhr = vhr_profile.get("nodata")
+    args.shape = (vhr_profile["height"], vhr_profile["width"])
+    args.crs = vhr_profile["crs"]
+    args.transform = vhr_profile["transform"]
 
     # ==============================
     # VALID STACK
@@ -223,7 +223,7 @@ def build_stack_shadow(args, slurp_manager):
     else:
         logger.info("No watermask provided ? creating empty mask")
 
-        empty_profile = deepcopy(phr_profile)
+        empty_profile = deepcopy(vhr_profile)
         empty_profile["count"] = 1
         empty_profile["dtype"] = np.uint8
 
@@ -234,11 +234,11 @@ def build_stack_shadow(args, slurp_manager):
     logger.info("Shadow stack ready")
 
     return (
-        [key_phr],
+        [key_vhr],
         [key_valid_stack],
         [key_watermask],
         margin,
-        phr_profile,
+        vhr_profile,
     )
 
 def getarguments() -> dict:
@@ -401,11 +401,11 @@ def slurp_shadowmask(
             logger.info("[0] Step: Build stack")
 
             (
-                phr,
+                vhr,
                 valid_stack,
                 watermask,
                 margin,
-                phr_profile,
+                vhr_profile,
             ) = build_stack_shadow(args, slurp_manager)
 
             # ==============================
@@ -414,12 +414,12 @@ def slurp_shadowmask(
 
             logger.info("[1] Step: Compute thresholds")
 
-            local_phr = phr[0]
+            local_vhr = vhr[0]
 
             th_bands = compute_thresholds(
                 args.absolute_threshold,
-                local_phr,
-                args.nodata_phr,
+                local_vhr,
+                args.nodata_vhr,
                 args.percentile,
                 args.th_rgb,
                 args.th_nir,
@@ -437,18 +437,18 @@ def slurp_shadowmask(
 
             logger.info("[2] Step: Shadow mask")
 
-            input_profile = deepcopy(phr_profile)
+            input_profile = deepcopy(vhr_profile)
             output_profile = eo_utils.single_uint8_profile(
-                [deepcopy(phr_profile)]
+                [deepcopy(vhr_profile)]
             )
             
 
             predict = mp_n_to_m_images(
                 inputs=[
-                    phr[0][0],
-                    phr[0][1],
-                    phr[0][2],
-                    phr[0][3],
+                    vhr[0][0],
+                    vhr[0][1],
+                    vhr[0][2],
+                    vhr[0][3],
                     valid_stack[0][0],
                     watermask[0][0],
                 ],

--- a/slurp/masks/shadowmask.py
+++ b/slurp/masks/shadowmask.py
@@ -29,13 +29,17 @@ import logging
 import time
 import traceback
 from os import path
+from copy import deepcopy
 
 import eoscale.eo_executors as eoexe
 import eoscale.manager as eom
 import numpy as np
 
+from slurp.eomultiprocessing.slurp_executor import mp_n_to_m_images, mp_n_to_m_scalars
+from slurp.eomultiprocessing.slurp_manager import slurpContextManager
+from slurp.eomultiprocessing.utils import read_and_get_profile, write, read, create_image
 from slurp.post_process.morphology import apply_morpho
-from slurp.tools import eoscale_utils as eo_utils
+from slurp.tools import profile_utils as eo_utils
 from slurp.tools import utils
 from slurp.tools.constant import NODATA_INT8
 
@@ -52,7 +56,7 @@ def compute_thresholds(
     specified percentile for each band, with different thresholds for RGB bands and NIR band.
     """
     if absolute_threshold is False:
-        # Compute threshold for each band
+        # Compute threshold for each bandx
         th_bands = np.zeros(4)
         for cpt in range(3):
             min_band = np.percentile(
@@ -85,55 +89,154 @@ def compute_thresholds(
 
 
 def compute_shadowmask(
-    input_buffers: list, input_profiles: list, params: dict
+    phr1: np.ndarray,
+    phr2: np.ndarray,
+    phr3: np.ndarray,
+    phr4: np.ndarray,
+    valid_stack: np.ndarray,
+    watermask: np.ndarray,
+    thresholds: list,
+    binary_opening: int,
+    remove_small_objects: int,
 ) -> np.ndarray:
     """
-    Compute shadow mask
+    Compute shadow mask from spectral bands.
 
-    :param list input_buffers: 0 -> image, 1 -> valid_stack, 2 -> watermask
-    :param list input_profiles: image profiles (not used but necessary for eoscale)
-    :param dict params: must contain the keys "thresholds",
-                                              "binary_opening" and "small_objects"
-    :returns: valid_mask (int numpy array) with following legend
-              0: no shadows, 1: small shadows, 2: big shadows, + NODATA
+    Parameters
+    ----------
+    phr1, phr2, phr3, phr4 : np.ndarray
+        Spectral bands.
+    valid_stack : np.ndarray
+        Validity mask.
+    watermask : np.ndarray
+        Water mask.
+    thresholds : list[float]
+        Thresholds for each band.
+    binary_opening : int
+    remove_small_objects : int
+
+    Returns
+    -------
+    np.ndarray
+        Shadow mask.
     """
-    raw_shadow_mask = np.zeros(input_buffers[0][0].shape, dtype=int)
-    raw_shadow_mask.fill(1)
 
-    for i in range(4):
-        raw_shadow_mask = np.logical_and(
-            raw_shadow_mask, input_buffers[0][i] < params["thresholds"][i]
-        )
+    # ------------------------------
+    # RAW SHADOW DETECTION
+    # ------------------------------
 
-    # Remove shadows on water areas
-    raw_shadow_mask[np.where(input_buffers[2][0] == 1)] = 0
+    raw_shadow_mask = (
+        (phr1 < thresholds[0])
+        & (phr2 < thresholds[1])
+        & (phr3 < thresholds[2])
+        & (phr4 < thresholds[3])
+    )
 
-    # work on binary arrays
-    final_shadow_mask = raw_shadow_mask
-    if params["binary_opening"] > 0:
+    # Remove water shadows
+    raw_shadow_mask[watermask == 1] = 0
+
+    # ------------------------------
+    # MORPHOLOGY
+    # ------------------------------
+
+    final_shadow_mask = raw_shadow_mask.copy()
+
+    if binary_opening > 0:
         final_shadow_mask = apply_morpho(
-            final_shadow_mask, "binary_opening", params["binary_opening"]
+            final_shadow_mask,
+            "binary_opening",
+            binary_opening,
         )
-    if params["remove_small_objects"] > 0:
+
+    if remove_small_objects > 0:
         final_shadow_mask = apply_morpho(
             final_shadow_mask,
             "remove_small_objects",
-            params["remove_small_objects"],
+            remove_small_objects,
         )
 
-    raw_shadow_mask = np.where(raw_shadow_mask, 1, 0)
-    final_shadow_mask = np.where(final_shadow_mask, 1, 0)
+    # ------------------------------
+    # MERGE RAW + FILTERED
+    # ------------------------------
 
-    # Sum between raw shadows and refined shadows
+    raw_shadow_mask = raw_shadow_mask.astype(np.uint8)
+    final_shadow_mask = final_shadow_mask.astype(np.uint8)
+
     final_shadow_mask += raw_shadow_mask
 
-    # apply NO_DATA mask
+    # ------------------------------
+    # APPLY NODATA
+    # ------------------------------
+
     final_shadow_mask = np.where(
-        input_buffers[1][0] == 0, final_shadow_mask, NODATA_INT8
+        valid_stack == 0,
+        final_shadow_mask,
+        NODATA_INT8,
     )
 
     return final_shadow_mask
 
+
+def build_stack_shadow(args, slurp_manager):
+    """
+    Prepare inputs for shadow mask processing.
+
+    Returns
+    -------
+    phr : list
+    valid_stack : list
+    watermask : list
+    margin : int
+    phr_profile : dict
+    """
+
+    logger.info("Loading base rasters")
+
+    # ==============================
+    # PHR
+    # ==============================
+
+    key_phr, phr_profile = read_and_get_profile(args.file_vhr)
+
+    args.nodata_phr = phr_profile.get("nodata")
+    args.shape = (phr_profile["height"], phr_profile["width"])
+    args.crs = phr_profile["crs"]
+    args.transform = phr_profile["transform"]
+
+    # ==============================
+    # VALID STACK
+    # ==============================
+
+    key_valid_stack = read(args.valid_stack)
+
+    # ==============================
+    # WATERMASK
+    # ==============================
+
+    if args.watermask and path.isfile(args.watermask):
+        logger.info("Loading watermask")
+        key_watermask = read(args.watermask)
+
+    else:
+        logger.info("No watermask provided ? creating empty mask")
+
+        empty_profile = deepcopy(phr_profile)
+        empty_profile["count"] = 1
+        empty_profile["dtype"] = np.uint8
+
+        key_watermask = create_image(empty_profile, fill_value=0)[0]
+
+    margin = args.remove_small_objects
+
+    logger.info("Shadow stack ready")
+
+    return (
+        [key_phr],
+        [key_valid_stack],
+        [key_watermask],
+        margin,
+        phr_profile,
+    )
 
 def getarguments() -> dict:
     """Parse command line arguments."""
@@ -241,11 +344,9 @@ def slurp_shadowmask(
     multiproc_context: str,
 ):
     """
-    Main API to compute shadow mask.
+    Main API to compute shadow mask using slurpContextManager.
     """
-    t0 = time.time()
 
-    # Read the JSON files
     keys = [
         "input",
         "aux_layers",
@@ -254,103 +355,135 @@ def slurp_shadowmask(
         "post_process",
         "shadows",
     ]
+
     argsdict, cli_params = utils.parse_args(keys, logs_to_file, main_config)
 
     for param in cli_params:
-        # If the parameter from the CLI is not None, we update argsdict with the value from the CLI
         if locals()[param] is not None:
             argsdict[param] = locals()[param]
 
     logger.info("--" * 50)
     logger.info("SLURP - Shadow mask\n")
     logger.info(f"JSON data loaded: {main_config}")
+
     args = argparse.Namespace(**argsdict)
 
     if args.debug:
         logger.handlers[0].setLevel(logging.DEBUG)
+
     logger.debug(f"{argsdict=}")
 
-    # Mask calculation
-    with eom.EOContextManager(
-        nb_workers=args.n_workers,
-        tile_mode=True,
-        tile_max_size=args.tile_max_size,
-    ) as eoscale_manager:
+    # ==============================
+    # SLURP CONTEXT
+    # ==============================
+
+    params = {
+        "nb_max_workers": args.n_workers,
+        "developer_mode": args.debug,
+        "method": "mem",
+        "mp_context": multiproc_context,
+        "output_dir": path.dirname(args.file_vhr),
+    }
+
+    with slurpContextManager(params, tile_mode=True) as slurp_manager:
+
         try:
 
-            # Store image in shared memory
-            key_phr = eoscale_manager.open_raster(raster_path=args.file_vhr)
-            local_phr = eoscale_manager.get_array(key_phr)
-            nodata = eoscale_manager.get_profile(key_phr)["nodata"]
+            t0 = time.time()
 
-            # Valid stack
-            key_valid_stack = eoscale_manager.open_raster(
-                raster_path=args.valid_stack
-            )
+            # ==============================
+            # BUILD STACK
+            # ==============================
+
+            logger.info("[0] Step: Build stack")
+
+            (
+                phr,
+                valid_stack,
+                watermask,
+                margin,
+                phr_profile,
+            ) = build_stack_shadow(args, slurp_manager)
+
+            # ==============================
+            # COMPUTE THRESHOLDS
+            # ==============================
+
+            logger.info("[1] Step: Compute thresholds")
+
+            local_phr = phr[0]
 
             th_bands = compute_thresholds(
                 args.absolute_threshold,
                 local_phr,
-                nodata,
+                args.nodata_phr,
                 args.percentile,
                 args.th_rgb,
                 args.th_nir,
             )
 
-            params = {
+            params_filter = {
                 "thresholds": th_bands,
                 "binary_opening": args.binary_opening,
                 "remove_small_objects": args.remove_small_objects,
             }
 
-            if args.watermask and path.isfile(args.watermask):
-                key_watermask = eoscale_manager.open_raster(
-                    raster_path=args.watermask
-                )
-            else:
-                profile = eoscale_manager.get_profile(key_phr)
-                profile["count"] = 1
-                profile["dtype"] = np.uint8
-                key_watermask = eoscale_manager.create_image(profile)
-                eoscale_manager.get_array(key=key_watermask).fill(0)
+            # ==============================
+            # SHADOW MASK PROCESSING
+            # ==============================
 
-            mask_shadow = eoexe.n_images_to_m_images_filter(
-                inputs=[key_phr, key_valid_stack, key_watermask],
-                image_filter=compute_shadowmask,
-                filter_parameters=params,
-                generate_output_profiles=eo_utils.single_uint8_profile,
-                stable_margin=args.remove_small_objects,
-                context_manager=eoscale_manager,
-                multiproc_context=args.multiproc_context,
-                filter_desc="Shadow mask processing...",
+            logger.info("[2] Step: Shadow mask")
+
+            input_profile = deepcopy(phr_profile)
+            output_profile = eo_utils.single_uint8_profile(
+                [deepcopy(phr_profile)]
+            )
+            
+
+            predict = mp_n_to_m_images(
+                inputs=[
+                    phr[0][0],
+                    phr[0][1],
+                    phr[0][2],
+                    phr[0][3],
+                    valid_stack[0][0],
+                    watermask[0][0],
+                ],
+                image_height=input_profile["height"],
+                image_width=input_profile["width"],
+                output_profiles=[output_profile],
+                output_keys=[path.basename(args.shadowmask)],
+                func=compute_shadowmask,
+                func_parameters=params_filter,
+                context_manager=slurp_manager,
+                stable_margin=margin,
+                binary=True,
             )
 
-            eoscale_manager.write(key=mask_shadow[0], img_path=args.shadowmask)
+            # ==============================
+            # WRITE OUTPUT
+            # ==============================
 
-            end_time = time.time()
+            slurp_manager.write_tif(
+                data=predict[0],
+                path=args.shadowmask,
+                target_profile=output_profile,
+            )
+
+            t1 = time.time()
+
             logger.info(
-                f"**** Shadow mask for {args.file_vhr} (saved as {args.shadowmask}) ****"
+                f"**** Shadow mask saved as {args.shadowmask} ****"
             )
             logger.info(
-                "Total time (user)       :\t"
-                + utils.convert_time(end_time - t0)
+                "Total time (user):\t" + utils.convert_time(t1 - t0)
             )
 
-        except FileNotFoundError as fnfe_exception:
-            logger.error("FileNotFoundError", fnfe_exception)
-
-        except PermissionError as pe_exception:
-            logger.error("PermissionError", pe_exception)
-
-        except ArithmeticError as ae_exception:
-            logger.error("ArithmeticError", ae_exception)
-
-        except MemoryError as me_exception:
-            logger.error("MemoryError", me_exception)
-
-        except Exception as exception:  # pylint: disable=broad-except
-            logger.error("oups...", exception)
+        except Exception:
+            logger.error("Unexpected error:", exc_info=True)
             traceback.print_exc()
+
+    logger.info("End of shadowmask step\n")
 
 
 def main():

--- a/slurp/masks/stack_masks.py
+++ b/slurp/masks/stack_masks.py
@@ -312,10 +312,10 @@ def choose_wb(kind_waterbodies):
 
 
 def post_process(
-    phr1: np.ndarray,
-    phr2: np.ndarray,
-    phr3: np.ndarray,
-    phr4: np.ndarray,
+    vhr1: np.ndarray,
+    vhr2: np.ndarray,
+    vhr3: np.ndarray,
+    vhr4: np.ndarray,
     valid_stack: np.ndarray,
     watermask: np.ndarray,
     vegmask: np.ndarray,
@@ -348,7 +348,7 @@ def post_process(
 
     Parameters
     ----------
-    phr1, phr2, phr3, phr4 : np.ndarray
+    vhr1, vhr2, vhr3, vhr4 : np.ndarray
         Four spectral bands of the VHR image.
     valid_stack : np.ndarray
         Validity mask defining nodata regions.
@@ -408,8 +408,8 @@ def post_process(
     """
 
     # Combine bands into a single array for watershed input
-    input_image = np.stack([phr1, phr2, phr3, phr4], axis=0)
-    h, w = phr1.shape
+    input_image = np.stack([vhr1, vhr2, vhr3, vhr4], axis=0)
+    h, w = vhr1.shape
 
     stack = np.zeros((1, h, w), dtype=np.uint8)
 
@@ -792,10 +792,10 @@ def slurp_stackmask(
 
             stack, height, markers  = mp_n_to_m_images(
                 inputs=[
-                    image[0][0],  # phr1
-                    image[0][1],  # phr2
-                    image[0][2],  # phr3
-                    image[0][3],  # phr4
+                    image[0][0],  # vhr1
+                    image[0][1],  # vhr2
+                    image[0][2],  # vhr3
+                    image[0][3],  # vhr4
                     validstack[0][0],
                     watermask[0][0],
                     vegmask[0][0],

--- a/slurp/masks/stack_masks.py
+++ b/slurp/masks/stack_masks.py
@@ -33,6 +33,7 @@ import logging
 import time
 import traceback
 from os import path
+from copy import deepcopy
 
 import eoscale.eo_executors as eoexe
 import eoscale.manager as eom
@@ -41,8 +42,11 @@ from skimage import segmentation
 from skimage.filters import sobel
 from skimage.measure import label
 
+from slurp.eomultiprocessing.slurp_executor import mp_n_to_m_images, mp_n_to_m_scalars
+from slurp.eomultiprocessing.slurp_manager import slurpContextManager
+from slurp.eomultiprocessing.utils import read_and_get_profile, write, read
 from slurp.post_process.morphology import apply_morpho, morpho_clean
-from slurp.tools import eoscale_utils as eo_utils
+from slurp.tools import profile_utils as eo_utils
 from slurp.tools import io_utils, utils
 from slurp.tools.constant import HIGH, LOW, NODATA_INT8
 
@@ -54,109 +58,120 @@ LAKE = 2
 RIVER = 3
 
 
+def build_stack_stackmask(args, slurp_manager):
+    """
+    Prepare inputs for stack mask post-processing.
+    """
+
+    logger.info("Loading base rasters")
+
+    # ==============================
+    # VHR IMAGE
+    # ==============================
+
+    key_image, image_profile = read_and_get_profile(args.file_vhr)
+    input_profile = deepcopy(image_profile)
+
+    args.shape = (input_profile["height"], input_profile["width"])
+    args.crs = input_profile["crs"]
+    args.transform = input_profile["transform"]
+    args.nodata_vhr = 0
+
+    # ==============================
+    # REQUIRED MASKS
+    # ==============================
+
+    key_validstack = read(args.valid_stack)
+    key_watermask = read(args.watermask)
+    key_vegmask = read(args.vegetationmask)
+    key_urbanmask = read(args.urbanmask)
+    key_shadowmask = read(args.shadowmask)
+    key_wsf = read(args.extracted_wsf)
+
+    margin = 100  # identical to previous stable_margin
+
+    logger.info("Stackmask inputs ready")
+
+    return (
+        [key_image],
+        [key_validstack],
+        [key_watermask],
+        [key_vegmask],
+        [key_urbanmask],
+        [key_shadowmask],
+        [key_wsf],
+        margin,
+        image_profile,
+    )
+
 def watershed_regul_buildings(
-    input_image, urbanmask, wsf, vegmask, watermask, shadowmask, params
+    input_image: np.ndarray,
+    urbanmask: np.ndarray,
+    wsf: np.ndarray,
+    vegmask: np.ndarray,
+    watermask: np.ndarray,
+    shadowmask: np.ndarray,
+    *,
+    sobel_image: str,
+    regul_type: str,
+    building_threshold: int,
+    building_erosion: int,
+    erosion_radius: int,
+    bonus_gt: int,
+    malus_shadow: int,
+    value_classif_bare_ground: int,
+    value_classif_buildings: int,
+    value_classif_low_veg: int,
+    value_classif_high_veg: int,
+    value_classif_false_positive_buildings: int,
+    value_classif_background: int,
 ):
     """
     Clean and apply watershed regulation for buildings
-
-    :param np.ndarray input_image: VHR input image
-    :param np.ndarray urbanmask: Urbanmask created by the dedicated script
-    :param np.ndarray wsf: WSF file from post_process function
-    :param np.ndarray vegmask: Vegetationnmask created by the dedicated script
-    :param np.ndarray watermask: Watermask created by the dedicated script
-    :param np.ndarray shadowmask: Shadowmask created by the dedicated script
-    :param dict params: dictionary of arguments
-    :return: tuple of segmentation value and markers
     """
-    # Compute mono image from RGB image
-    # im_mono = 0.29*input_image[0] + 0.58*input_image[1] + 0.114*input_image[2]
-    if params["sobel_image"] == "ndvi":
-        im_mono = (input_image[3] - input_image[0]) / (
-            input_image[3] + input_image[0]
-        )
-    elif params["sobel_image"] == "nir":
+
+    # Mono image for edge detection
+    if sobel_image == "ndvi":
+        im_mono = (input_image[3] - input_image[0]) / (input_image[3] + input_image[0])
+    elif sobel_image == "nir":
         im_mono = input_image[3]
     else:
-        im_mono = (
-            0.29 * input_image[0]
-            + 0.58 * input_image[1]
-            + 0.114 * input_image[2]
-        )
-    edges = sobel(im_mono)
+        im_mono = 0.29 * input_image[0] + 0.58 * input_image[1] + 0.114 * input_image[2]
 
+    edges = sobel(im_mono)
     markers = np.zeros((1, input_image.shape[1], input_image.shape[2]))
 
-    # We set markers by reverse order of confidence
-    eroded_bare_ground = apply_morpho(
-        vegmask[0] == 11, "binary_erosion", params["erosion_radius"]
-    )
-    if params["regul_type"] == "all":
-        markers[0][eroded_bare_ground] = params["value_classif_bare_ground"]
-    else:
-        markers[0][eroded_bare_ground] = params["value_classif_background"]
+    # Bare ground
+    eroded_bare_ground = apply_morpho(vegmask == 11, "binary_erosion", erosion_radius)
+    markers[0][eroded_bare_ground] = value_classif_bare_ground if regul_type == "all" else value_classif_background
 
-    ground_truth_eroded = apply_morpho(
-        wsf[0] == 255, "binary_erosion", params["erosion_radius"]
-    )
+    # Buildings
+    ground_truth_eroded = apply_morpho(wsf == 255, "binary_erosion", erosion_radius)
+    normalized_building_threshold = np.percentile(urbanmask, building_threshold)
+    urbanmask[ground_truth_eroded] += bonus_gt
+    urbanmask[shadowmask == 2] -= malus_shadow
+    probable_buildings = np.logical_and(ground_truth_eroded, urbanmask > normalized_building_threshold)
+    probable_buildings = apply_morpho(probable_buildings, "binary_erosion", building_erosion)
+    false_positive = np.logical_and(apply_morpho(wsf == 255, "binary_dilation", 10) == 0, urbanmask > normalized_building_threshold)
+    markers[0][probable_buildings] = value_classif_buildings
+    markers[0][false_positive] = value_classif_false_positive_buildings
 
-    normalized_building_threshold = np.percentile(
-        urbanmask[0], params["building_threshold"]
-    )
-    logger.debug(
-        f"Normalized building threshold {normalized_building_threshold}"
-    )
+    # Low vegetation
+    eroded_low_veg = apply_morpho(vegmask == 21, "binary_erosion", erosion_radius)
+    markers[0][eroded_low_veg] = value_classif_low_veg if regul_type == "all" else value_classif_background
 
-    # Bonus for pixels above ground truth
-    urbanmask[0][ground_truth_eroded] += params["bonus_gt"]
-    # Malus for pixels in shadow areas
-    urbanmask[0][shadowmask[0] == 2] -= params["malus_shadow"]
-    probable_buildings = np.logical_and(
-        ground_truth_eroded, urbanmask[0] > normalized_building_threshold
-    )
-    probable_buildings = apply_morpho(
-        probable_buildings, "binary_erosion", params["building_erosion"]
-    )
-    # TODO : validate marker
-    false_positive = np.logical_and(
-        apply_morpho(wsf[0] == 255, "binary_dilation", 10) == 0,
-        urbanmask[0] > normalized_building_threshold,
-    )
+    # High vegetation
+    eroded_high_veg = apply_morpho(np.logical_or(vegmask == 23, vegmask == 22), "binary_erosion", erosion_radius)
+    markers[0][eroded_high_veg] = value_classif_high_veg if regul_type == "all" else value_classif_background
 
-    markers[0][probable_buildings] = params["value_classif_buildings"]
-    markers[0][false_positive] = params[
-        "value_classif_false_positive_buildings"
-    ]
+    # Shadow
+    eroded_shadow = apply_morpho(shadowmask == 2, "binary_erosion", erosion_radius)
+    markers[0][eroded_shadow] = value_classif_background
 
-    eroded_low_veg = apply_morpho(
-        vegmask[0] == 21, "binary_erosion", params["erosion_radius"]
-    )
-    if params["regul_type"] == "all":
-        markers[0][eroded_low_veg] = params["value_classif_low_veg"]
-    else:
-        markers[0][eroded_low_veg] = params["value_classif_background"]
-
-    # careful : vegetation mask has two values for high veg !
-    eroded_high_veg = apply_morpho(
-        np.logical_or(vegmask[0] == 23, vegmask[0] == 22),
-        "binary_erosion",
-        params["erosion_radius"],
-    )
-
-    if params["regul_type"] == "all":
-        markers[0][eroded_high_veg] = params["value_classif_high_veg"]
-    else:
-        markers[0][eroded_high_veg] = params["value_classif_background"]
-
-    eroded_shadow = apply_morpho(
-        shadowmask[0] == 2, "binary_erosion", params["erosion_radius"]
-    )
-    markers[0][eroded_shadow] = params["value_classif_background"]
-
-    markers[watermask == 1] = params["value_classif_background"]
+    # Water
+    markers[0][watermask == 1] = value_classif_background
 
     seg = segmentation.watershed(edges, markers[0].astype(np.uint8))
-
     return seg, markers
 
 
@@ -170,7 +185,7 @@ def infer_waterbodies_type(wbm, watermask, params):
     :return: categorized mask
     """
     nb_iter = 2
-    clean_watermask = watermask[0] == 1
+    clean_watermask = watermask == 1
     for _ in range(nb_iter):
         clean_watermask = apply_morpho(clean_watermask, "binary_opening", 2)
 
@@ -209,7 +224,7 @@ def infer_waterbodies_type(wbm, watermask, params):
         # values from WBM covered by value 'val' in label_image
         if 1 in watermask_remove[mask_val]:
             # water body
-            sub_set_wbm = wbm[0][mask_val]
+            sub_set_wbm = wbm[mask_val]
             kind_waterbodies = np.unique(sub_set_wbm)
             # We select water body type by priority order
             # sea > lake > river > (other) water
@@ -231,83 +246,137 @@ def choose_wb(kind_waterbodies):
 
 
 def post_process(
-    input_buffer: list, input_profiles: list, params: dict
-) -> np.ndarray:
+    phr1: np.ndarray,
+    phr2: np.ndarray,
+    phr3: np.ndarray,
+    phr4: np.ndarray,
+    valid_stack: np.ndarray,
+    watermask: np.ndarray,
+    vegmask: np.ndarray,
+    urbanmask: np.ndarray,
+    shadowmask: np.ndarray,
+    wsf: np.ndarray,
+    *,
+    winter_vegetation: bool,
+    value_classif_bare_ground: int,
+    value_classif_buildings: int,
+    value_classif_water: int,
+    value_classif_low_veg: int,
+    value_classif_high_veg: int,
+    value_classif_false_positive_buildings: int,
+    value_classif_background: int,
+    sobel_image: str,
+    regul_type: str,
+    building_threshold: int,
+    building_erosion: int,
+    erosion_radius: int,
+    bonus_gt: int,
+    malus_shadow: int,
+    binary_closing: int | None = None,
+    binary_opening: int | None = None,
+    remove_small_holes: int | None = None,
+    remove_small_objects: int | None = None,
+):
     """
-    key_image, key_validstack, key_watermask, key_vegmask, key_urbanmask, key_shadowmask,
-    0          1              2              3             4              5
-    key_wsf [, key_wbm ]
-    6       [ 7 ]
+    SLURP post-processing kernel (explicit inputs version)
+    phr1..phr4 correspond to the 4 bands of the input VHR image.
     """
-    input_image = input_buffer[0]
-    valid_stack = input_buffer[1]
-    watermask = input_buffer[2]
-    vegmask = input_buffer[3]
-    urbanmask = input_buffer[4]
-    shadowmask = input_buffer[5]
-    wsf = input_buffer[6]
 
-    # 1st channel is the class, 2nd is an estimation of height class,
-    # 3rd the markers layer, for debug purpose
-    stack = np.zeros((1, input_image.shape[1], input_image.shape[2]))
+    # Combine bands into a single array for watershed input
+    input_image = np.stack([phr1, phr2, phr3, phr4], axis=0)
+    h, w = phr1.shape
 
-    # If "winter vegetation" is activated, medium "NDVI" but textured segments
-    # (classified as 12/13) by vegetation mask will be considered as high vegetation
-    if params["winter_vegetation"]:
-        mix_textured_veg = np.logical_or(vegmask[0] == 12, vegmask[0] == 13)
-        vegmask[0][mix_textured_veg] = 22
+    stack = np.zeros((1, h, w), dtype=np.uint8)
 
-    # Improve buildings detection using a watershed / markers regularization
+    # ==============================
+    # Winter vegetation correction
+    # ==============================
+    if winter_vegetation:
+        mix_textured_veg = np.logical_or(
+            vegmask == 12,
+            vegmask == 13,
+        )
+        vegmask[mix_textured_veg] = 22
+
+    # ==============================
+    # Watershed regularisation
+    # ==============================
     seg, markers = watershed_regul_buildings(
-        input_image, urbanmask, wsf, vegmask, watermask, shadowmask, params
+        input_image=input_image,
+        urbanmask=urbanmask,
+        wsf=wsf,
+        vegmask=vegmask,
+        watermask=watermask,
+        shadowmask=shadowmask,
+        sobel_image=sobel_image,
+        regul_type=regul_type,
+        building_threshold=building_threshold,
+        building_erosion=building_erosion,
+        erosion_radius=erosion_radius,
+        bonus_gt=bonus_gt,
+        malus_shadow=malus_shadow,
+        value_classif_bare_ground=value_classif_bare_ground,
+        value_classif_buildings=value_classif_buildings,
+        value_classif_low_veg=value_classif_low_veg,
+        value_classif_high_veg=value_classif_high_veg,
+        value_classif_false_positive_buildings=value_classif_false_positive_buildings,
+        value_classif_background=value_classif_background,
     )
     logger.debug(f"{np.unique(seg)=}")
 
+    # ==============================
+    # Classes cleaning
+    # ==============================
     clean_bare_ground = (
-        morpho_clean(seg == params["value_classif_bare_ground"], params) == 1
-    )
-    stack[0][clean_bare_ground] = params["value_classif_bare_ground"]
+    morpho_clean(
+        seg == value_classif_bare_ground,
+        binary_closing=binary_closing,
+        binary_opening=binary_opening,
+        remove_small_holes=remove_small_holes,
+        remove_small_objects=remove_small_objects,
+    ) == 1
+)
+    stack[0][clean_bare_ground] = value_classif_bare_ground
 
-    clean_buildings = (
-        morpho_clean(seg == params["value_classif_buildings"], params) == 1
-    )
-    stack[0][clean_buildings] = params["value_classif_buildings"]
+    clean_buildings = morpho_clean(
+        seg == value_classif_buildings, 
+        binary_closing=binary_closing,
+        binary_opening=binary_opening,
+        remove_small_holes=remove_small_holes,
+        remove_small_objects=remove_small_objects,
+    ) == 1
+    stack[0][clean_buildings] = value_classif_buildings
 
-    # Note : Watermask and vegetation mask should be quite clean and don't need morpho postprocess
-    stack[0][watermask[0] == 1] = params["value_classif_water"]
+    stack[0][watermask == 1] = value_classif_water
 
-    clean_low_veg = vegmask[0] == 21
-    stack[0][clean_low_veg] = params["value_classif_low_veg"]
+    clean_low_veg = vegmask == 21
+    stack[0][clean_low_veg] = value_classif_low_veg
 
-    clean_high_veg = vegmask[0] == 22
-    stack[0][clean_high_veg] = params["value_classif_high_veg"]
+    clean_high_veg = vegmask == 22
+    stack[0][clean_high_veg] = value_classif_high_veg
 
-    # Apply NODATA
-    stack[0][np.where(valid_stack[0] != 0)] = NODATA_INT8
+    stack[0][valid_stack != 0] = NODATA_INT8
 
-    height_layer = np.zeros((1, input_image.shape[1], input_image.shape[2]))
-
-    # Estimation of heigth
-    # Supposed to be low
+    # ==============================
+    # HEIGHT LAYER
+    # ==============================
+    height_layer = np.zeros((1, h, w), dtype=np.uint8)
     height_layer[0][clean_bare_ground] = LOW
     height_layer[0][clean_low_veg] = LOW
-
-    # Supposed to be high
     height_layer[0][clean_buildings] = HIGH
     height_layer[0][clean_high_veg] = HIGH
+    height_layer[0][watermask == 1] = 0
+    height_layer[0][shadowmask == 2] = 0
+    height_layer[0][valid_stack != 0] = NODATA_INT8
 
-    # No confidence in heigh
-    height_layer[0][watermask[0] == 1] = 0
-    height_layer[0][shadowmask[0] == 2] = 0
-
-    height_layer[0][np.where(valid_stack[0] != 0)] = NODATA_INT8
-
-    markers_layer = np.zeros((1, input_image.shape[1], input_image.shape[2]))
-    # Markers
+    # ==============================
+    # MARKERS
+    # ==============================
+    markers_layer = np.zeros((1, h, w), dtype=np.uint8)
     markers_layer[0] = markers
-    markers_layer[0][np.where(valid_stack[0] != 0)] = NODATA_INT8
+    markers_layer[0][valid_stack != 0] = NODATA_INT8
 
-    return [stack, height_layer, markers_layer]
+    return stack[0], height_layer[0], markers_layer[0]
 
 
 def getarguments():
@@ -492,7 +561,6 @@ def getarguments():
 
     return vars(args)
 
-
 def slurp_stackmask(
     main_config: str,
     logs_to_file: bool,
@@ -528,10 +596,7 @@ def slurp_stackmask(
     categorized_watermask: bool,
     minimal_size_water_area: int,
 ):
-    """
-    Main API to compute urban mask.
-    """
-    # Read the JSON files
+
     keys = [
         "input",
         "prepare",
@@ -541,11 +606,10 @@ def slurp_stackmask(
         "post_process",
         "stack",
     ]
+
     argsdict, cli_params = utils.parse_args(keys, logs_to_file, main_config)
 
     for param in cli_params:
-        # If the parameter from the CLI is not None,
-        # we update argsdict with the value from the CLI
         if locals()[param] is not None:
             argsdict[param] = locals()[param]
 
@@ -554,133 +618,157 @@ def slurp_stackmask(
     logger.info(f"JSON data loaded: {main_config}")
 
     args = argparse.Namespace(**argsdict)
+
     if args.debug:
         logger.handlers[0].setLevel(logging.DEBUG)
-    logger.debug(f"{argsdict=}")
 
-    # Mask calculation
-    with eom.EOContextManager(
-        nb_workers=args.n_workers,
-        tile_mode=True,
-        tile_max_size=args.tile_max_size,
-    ) as eoscale_manager:
+    params = {
+        "nb_max_workers": args.n_workers,
+        "developer_mode": args.debug,
+        "method": "mem",
+        "mp_context": multiproc_context,
+        "output_dir": path.dirname(args.file_vhr),
+    }
+
+    with slurpContextManager(params, tile_mode=True) as slurp_manager:
+
         try:
+
             t0 = time.time()
-            key_image = eoscale_manager.open_raster(raster_path=args.file_vhr)
 
-            key_watermask = eoscale_manager.open_raster(
-                raster_path=args.watermask
-            )
-            key_vegmask = eoscale_manager.open_raster(
-                raster_path=args.vegetationmask
-            )
-            key_urbanmask = eoscale_manager.open_raster(
-                raster_path=args.urbanmask
-            )
-            key_shadowmask = eoscale_manager.open_raster(
-                raster_path=args.shadowmask
-            )
-            key_wsf = eoscale_manager.open_raster(
-                raster_path=args.extracted_wsf
-            )
-            key_validstack = eoscale_manager.open_raster(
-                raster_path=args.valid_stack
-            )
-            inputs_final = [
-                key_image,
-                key_validstack,
-                key_watermask,
-                key_vegmask,
-                key_urbanmask,
-                key_shadowmask,
-                key_wsf,
-            ]
-            args.nodata_vhr = 0  # TODO : get nodata value from image profile
+            # ==============================
+            # BUILD STACK
+            # ==============================
 
-            logger.info("Before post process")
-            key_final_mask = eoexe.n_images_to_m_images_filter(
-                inputs=inputs_final,
-                image_filter=post_process,
-                filter_parameters=vars(args),
-                generate_output_profiles=eo_utils.three_uint8_profile,
-                stable_margin=100,  # TODO : add a stability margin parameter ?
-                context_manager=eoscale_manager,
-                multiproc_context=args.multiproc_context,
-                filter_desc="Post processing...",
+            logger.info("[0] Step: Build stack")
+
+            (
+                image,
+                validstack,
+                watermask,
+                vegmask,
+                urbanmask,
+                shadowmask,
+                wsf,
+                margin,
+                image_profile,
+            ) = build_stack_stackmask(args, slurp_manager)
+
+            # ==============================
+            # POST PROCESS
+            # ==============================
+
+            logger.info("[1] Step: Post processing")
+
+            input_profile = deepcopy(image_profile)
+            output_profile = eo_utils.three_uint8_profile(
+                [deepcopy(image_profile)]
             )
 
-            # 1st layer : stack mask
-            logger.debug(f"{args.categorized_watermask=}")
+            stack, height, markers  = mp_n_to_m_images(
+                inputs=[
+                    image[0][0],  # phr1
+                    image[0][1],  # phr2
+                    image[0][2],  # phr3
+                    image[0][3],  # phr4
+                    validstack[0][0],
+                    watermask[0][0],
+                    vegmask[0][0],
+                    urbanmask[0][0],
+                    shadowmask[0][0],
+                    wsf[0][0],
+                ],
+                image_height=input_profile["height"],
+                image_width=input_profile["width"],
+                output_profiles=output_profile,
+                output_keys=["stack", "height", "markers"],
+                func=post_process,
+                func_parameters=dict(
+                    winter_vegetation=args.winter_vegetation,
+                    value_classif_bare_ground=args.value_classif_bare_ground,
+                    value_classif_buildings=args.value_classif_buildings,
+                    value_classif_water=args.value_classif_water,
+                    value_classif_low_veg=args.value_classif_low_veg,
+                    value_classif_high_veg=args.value_classif_high_veg,
+                    value_classif_false_positive_buildings=args.value_classif_false_positive_buildings,
+                    value_classif_background=args.value_classif_background,
+                    sobel_image=args.sobel_image,
+                    regul_type=args.regul_type,
+                    building_threshold=args.building_threshold,
+                    building_erosion=args.building_erosion,
+                    erosion_radius=args.erosion_radius,
+                    bonus_gt=args.bonus_gt,
+                    malus_shadow=args.malus_shadow,
+                    binary_closing=args.binary_closing,
+                    binary_opening=args.binary_opening,
+                    remove_small_holes=args.remove_small_holes,
+                    remove_small_objects=args.remove_small_objects,
+                ),
+                context_manager=slurp_manager,
+                stable_margin=margin,
+            )
+
+            # ==============================
+            # WRITE STACK
+            # ==============================
+
             if args.categorized_watermask:
-                key_wbm = eoscale_manager.open_raster(
-                    raster_path=args.extracted_wbm
+
+                key_wbm = read(args.extracted_wbm)
+                wbm = key_wbm[0]
+                water = watermask[0][0]
+
+                categorized = infer_waterbodies_type(
+                    wbm,
+                    water,
+                    vars(args),
                 )
-                wbm = eoscale_manager.get_array(key_wbm)  # input_buffer[7]
-                watermask = eoscale_manager.get_array(key_watermask)
-                categorized_watermask = infer_waterbodies_type(
-                    wbm, watermask, vars(args)
-                )
-                stack = eoscale_manager.get_array(key_final_mask[0])
-                stack[0] = np.where(
-                    categorized_watermask != 0, categorized_watermask, stack[0]
-                )
-                profile_stack = eoscale_manager.get_profile(key_final_mask[0])
+
+                stack[:] = np.where(categorized != 0, categorized, stack)
                 io_utils.save_image(
-                    stack[0],
+                    stack,
                     args.stackmask,
-                    crs=profile_stack["crs"],
-                    transform=profile_stack["transform"],
+                    crs=output_profile[0]["crs"],
+                    transform=output_profile[0]["transform"],
                 )
             else:
-                eoscale_manager.write(
-                    key=key_final_mask[0], img_path=args.stackmask
+                slurp_manager.write_tif(
+                    data=stack,
+                    path=args.stackmask,
+                    target_profile=output_profile[0],
                 )
 
             if args.debug:
-                # 2nd layer : mask of (supposed) ground areas / (supposed) structures
-                stackmask_filename = path.basename(args.stackmask)
-                height_mask = str.replace(
-                    args.stackmask,
-                    path.splitext(stackmask_filename)[0],
-                    path.splitext(stackmask_filename)[0] + "_height",
-                )
-                eoscale_manager.write(
-                    key=key_final_mask[1], img_path=height_mask
+
+                base = path.splitext(args.stackmask)[0]
+
+                slurp_manager.write_tif(
+                    data=height,
+                    path=base + "_height.tif",
+                    target_profile=output_profile[1],
                 )
 
-                # 3rd layer : mask of markers (debug purpose)
-                markers_mask = str.replace(
-                    args.stackmask,
-                    path.splitext(stackmask_filename)[0],
-                    path.splitext(stackmask_filename)[0] + "_markers",
-                )
-                eoscale_manager.write(
-                    key=key_final_mask[2], img_path=markers_mask
+                slurp_manager.write_tif(
+                    data=markers,
+                    path=base + "_markers.tif",
+                    target_profile=output_profile[2],
                 )
 
             t1 = time.time()
+
             logger.info(
-                f"**** Stack masks for {args.file_vhr} (saved as {args.stackmask}) ****"
+                f"**** Stack masks saved as {args.stackmask} ****"
             )
             logger.info(
-                "Total time (user)       :\t" + utils.convert_time(t1 - t0)
+                "Total time (user):\t"
+                + utils.convert_time(t1 - t0)
             )
 
-        except FileNotFoundError as fnfe_exception:
-            logger.error("FileNotFoundError", fnfe_exception)
-
-        except PermissionError as pe_exception:
-            logger.error("PermissionError", pe_exception)
-
-        except ArithmeticError as ae_exception:
-            logger.error("ArithmeticError", ae_exception)
-
-        except MemoryError as me_exception:
-            logger.error("MemoryError", me_exception)
-
-        except Exception as exception:  # pylint: disable=broad-except
-            logger.error("oups...", exception)
+        except Exception:
+            logger.error("Unexpected error:", exc_info=True)
             traceback.print_exc()
+
+    logger.info("End of stackmask step\n")
 
 
 def main():

--- a/slurp/masks/stack_masks.py
+++ b/slurp/masks/stack_masks.py
@@ -35,8 +35,6 @@ import traceback
 from os import path
 from copy import deepcopy
 
-import eoscale.eo_executors as eoexe
-import eoscale.manager as eom
 import numpy as np
 from skimage import segmentation
 from skimage.filters import sobel

--- a/slurp/masks/stack_masks.py
+++ b/slurp/masks/stack_masks.py
@@ -58,7 +58,29 @@ RIVER = 3
 
 def build_stack_stackmask(args, slurp_manager):
     """
-    Prepare inputs for stack mask post-processing.
+    Prepare inputs required for stack mask post-processing.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Input arguments containing paths to required rasters.
+    slurp_manager : object
+        SLURP manager instance (unused but kept for interface consistency).
+
+    Returns
+    -------
+    tuple
+        (
+            vhr_image_list,
+            valid_stack_list,
+            watermask_list,
+            vegmask_list,
+            urbanmask_list,
+            shadowmask_list,
+            wsf_list,
+            margin,
+            image_profile,
+        )
     """
 
     logger.info("Loading base rasters")
@@ -125,7 +147,53 @@ def watershed_regul_buildings(
     value_classif_background: int,
 ):
     """
-    Clean and apply watershed regulation for buildings
+    Apply watershed-based regularization to refine building classification.
+
+    Parameters
+    ----------
+    input_image : np.ndarray
+        Multi-band VHR image (bands, height, width).
+    urbanmask : np.ndarray
+        Urban probability or classification mask.
+    wsf : np.ndarray
+        World Settlement Footprint mask used as building ground truth.
+    vegmask : np.ndarray
+        Vegetation classification mask.
+    watermask : np.ndarray
+        Binary water mask.
+    shadowmask : np.ndarray
+        Shadow classification mask.
+    sobel_image : str
+        Image type used for edge detection ("ndvi", "nir", or "rgb").
+    regul_type : str
+        Regulation mode controlling which classes are enforced.
+    building_threshold : int
+        Percentile threshold applied to urbanmask.
+    building_erosion : int
+        Erosion radius applied to detected buildings.
+    erosion_radius : int
+        Morphological erosion radius for marker generation.
+    bonus_gt : int
+        Bonus value applied to ground-truth building pixels.
+    malus_shadow : int
+        Penalty applied to shadow pixels.
+    value_classif_bare_ground : int
+        Output value for bare ground class.
+    value_classif_buildings : int
+        Output value for buildings class.
+    value_classif_low_veg : int
+        Output value for low vegetation class.
+    value_classif_high_veg : int
+        Output value for high vegetation class.
+    value_classif_false_positive_buildings : int
+        Output value for false positive buildings.
+    value_classif_background : int
+        Output value for background class.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        (segmentation_map, markers)
     """
 
     # Mono image for edge detection
@@ -276,8 +344,67 @@ def post_process(
     remove_small_objects: int | None = None,
 ):
     """
-    SLURP post-processing kernel (explicit inputs version)
-    phr1..phr4 correspond to the 4 bands of the input VHR image.
+    Perform SLURP post-processing to generate final classification layers.
+
+    Parameters
+    ----------
+    phr1, phr2, phr3, phr4 : np.ndarray
+        Four spectral bands of the VHR image.
+    valid_stack : np.ndarray
+        Validity mask defining nodata regions.
+    watermask : np.ndarray
+        Binary water mask.
+    vegmask : np.ndarray
+        Vegetation classification mask.
+    urbanmask : np.ndarray
+        Urban probability or classification mask.
+    shadowmask : np.ndarray
+        Shadow classification mask.
+    wsf : np.ndarray
+        World Settlement Footprint mask.
+    winter_vegetation : bool
+        Enable winter vegetation correction.
+    value_classif_bare_ground : int
+        Output value for bare ground class.
+    value_classif_buildings : int
+        Output value for buildings class.
+    value_classif_water : int
+        Output value for water class.
+    value_classif_low_veg : int
+        Output value for low vegetation class.
+    value_classif_high_veg : int
+        Output value for high vegetation class.
+    value_classif_false_positive_buildings : int
+        Output value for false positive buildings.
+    value_classif_background : int
+        Output value for background class.
+    sobel_image : str
+        Image type used for watershed edge detection.
+    regul_type : str
+        Regulation mode applied during watershed segmentation.
+    building_threshold : int
+        Percentile threshold for building detection.
+    building_erosion : int
+        Morphological erosion radius for buildings.
+    erosion_radius : int
+        Radius used for marker erosion.
+    bonus_gt : int
+        Bonus applied to ground-truth buildings.
+    malus_shadow : int
+        Penalty applied to shadow areas.
+    binary_closing : int | None, optional
+        Closing kernel size for morphological cleaning.
+    binary_opening : int | None, optional
+        Opening kernel size for morphological cleaning.
+    remove_small_holes : int | None, optional
+        Minimum hole size removed during cleaning.
+    remove_small_objects : int | None, optional
+        Minimum object size removed during cleaning.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray, np.ndarray]
+        (classification_layer, height_layer, markers_layer)
     """
 
     # Combine bands into a single array for watershed input

--- a/slurp/post_process/morphology.py
+++ b/slurp/post_process/morphology.py
@@ -67,40 +67,36 @@ def apply_morpho(input_array: np.ndarray, key: str, value: int) -> np.ndarray:
     return output_array
 
 
-def morpho_clean(im_classif, params):
+def morpho_clean(
+    im_classif: np.ndarray,
+    *,
+    binary_closing: int | None = None,
+    binary_opening: int | None = None,
+    remove_small_holes: int | None = None,
+    remove_small_objects: int | None = None,
+) -> np.ndarray:
     """
-    Apply the morphology transformation passed in arguments
+    Apply morphology transformations on a classification mask.
 
-    :param np.ndarray im_classif: input array
-    :param dict params: dictionary of arguments
+    :param im_classif: input classification array
+    :param binary_closing: closing radius (optional)
+    :param binary_opening: opening radius (optional)
+    :param remove_small_holes: minimum size of small holes to remove
+    :param remove_small_objects: minimum size of small objects to remove
+    :return: transformed classification mask
     """
-
     im_classif = im_classif.astype(np.uint8)
 
-    if params["binary_closing"]:
-        # Closing can remove small dark spots (i.e. “pepper”) and connect small bright cracks.
-        im_classif = apply_morpho(
-            im_classif, "binary_closing", params["binary_closing"]
-        ).astype(np.uint8)
+    if binary_closing:
+        im_classif = apply_morpho(im_classif, "binary_closing", binary_closing).astype(np.uint8)
 
-    if params["binary_opening"]:
-        # Opening can remove small bright spots (i.e. “salt”) and connect small dark cracks.
-        im_classif = apply_morpho(
-            im_classif, "binary_opening", params["binary_opening"]
-        ).astype(np.uint8)
+    if binary_opening:
+        im_classif = apply_morpho(im_classif, "binary_opening", binary_opening).astype(np.uint8)
 
-    if params["remove_small_holes"]:
-        im_classif = apply_morpho(
-            im_classif.astype(bool),
-            "remove_small_holes",
-            params["remove_small_holes"],
-        ).astype(np.uint8)
+    if remove_small_holes:
+        im_classif = apply_morpho(im_classif.astype(bool), "remove_small_holes", remove_small_holes).astype(np.uint8)
 
-    if params["remove_small_objects"]:
-        im_classif = apply_morpho(
-            im_classif.astype(bool),
-            "remove_small_objects",
-            params["remove_small_objects"],
-        ).astype(np.uint8)
+    if remove_small_objects:
+        im_classif = apply_morpho(im_classif.astype(bool), "remove_small_objects", remove_small_objects).astype(np.uint8)
 
     return im_classif


### PR DESCRIPTION
# PR For Both #50 & #51 (shadow & stack)

eoscale removed in functions called : 
- [X] Compute_shadow_mask (shadowmask.py)
- [X] Post_process (stackmask.py)

# Results

For shadowmask results refer to issue : #50 
For stackmask results refer to issue : #51 

# Tests
```
Name                                        Stmts   Miss  Cover
---------------------------------------------------------------
slurp/__init__.py                               7      0   100%
slurp/eomultiprocessing/__init__.py             0      0   100%
slurp/eomultiprocessing/slurp_executor.py     153    110    28%
slurp/eomultiprocessing/slurp_manager.py       46     16    65%
slurp/eomultiprocessing/utils.py               52     17    67%
slurp/masks/__init__.py                         7      0   100%
slurp/masks/shadowmask.py                     135      7    95%
slurp/masks/stack_masks.py                    220     13    94%
slurp/masks/urbanmask.py                      230     80    65%
slurp/masks/vegetationmask.py                 354     60    83%
slurp/masks/watermask.py                      357     35    90%
slurp/post_process/__init__.py                  0      0   100%
slurp/post_process/morphology.py               32      4    88%
slurp/prepare/__init__.py                       7      0   100%
slurp/prepare/analyse_glcm.py                  73      9    88%
slurp/prepare/aux_files.py                      7      0   100%
slurp/prepare/geometry.py                     110      2    98%
slurp/prepare/prepare.py                      227     29    87%
slurp/prepare/primitives.py                    29      0   100%
slurp/prepare/validity.py                      10      2    80%
slurp/tools/__init__.py                         7      0   100%
slurp/tools/constant.py                         7      0   100%
slurp/tools/eoscale_utils.py                   80     43    46%
slurp/tools/io_utils.py                        30      7    77%
slurp/tools/misc.py                            26     26     0%
slurp/tools/mylogger.py                        27     14    48%
slurp/tools/profile_utils.py                   78     20    74%
slurp/tools/pydantic_class.py                 144      0   100%
slurp/tools/random_forest_utils.py             23      0   100%
slurp/tools/utils.py                           56      7    88%
---------------------------------------------------------------
TOTAL                                        2534    501    80%
Coverage HTML written to dir htmlcov
====== 42 passed, 23 deselected, 106 warnings in 703.48s (0:11:43) =======
```