### PR TITLE
adding support to n bands images in slurp mp executor

### DIFF
--- a/slurp/eomultiprocessing/slurp_executor.py
+++ b/slurp/eomultiprocessing/slurp_executor.py
@@ -346,8 +346,10 @@ def _validate_inputs(
     aux_inputs = aux_inputs or []
 
     for arr in aux_inputs:
-        if arr.shape != (h, w):
-            raise ValueError("All aux_inputs must match image dimensions")
+        if arr.shape[0] != h or arr.shape[1] != w:
+            raise ValueError(
+                "All aux_inputs must match image spatial dimensions"
+        )
 
     return func_parameters, aux_inputs, has_aux
 
@@ -542,10 +544,24 @@ def _run_streaming(
 # ============================================================
 
 def _slice_array(arr, tile):
-    return arr[
-        tile.start_y - tile.top_margin : tile.end_y + tile.bottom_margin + 1,
-        tile.start_x - tile.left_margin : tile.end_x + tile.right_margin + 1,
-    ]
+    ys = slice(
+        tile.start_y - tile.top_margin,
+        tile.end_y + tile.bottom_margin + 1,
+    )
+    xs = slice(
+        tile.start_x - tile.left_margin,
+        tile.end_x + tile.right_margin + 1,
+    )
+
+    if arr.ndim == 2:
+        return arr[ys, xs]
+
+    elif arr.ndim >= 3:
+        # keep all extra dims (bands, features, etc.)
+        return arr[ys, xs, ...]
+
+    else:
+        raise ValueError("Unsupported array dimensions")
 
 
 def _normalize_output(output):
@@ -559,18 +575,35 @@ def _normalize_output(output):
 
 
 def _reconstruct_outputs(chunks, h, w, output_profiles):
-    outputs = [
-        np.zeros((h, w), dtype=output_profiles[i]["dtype"])
-        for i in range(len(output_profiles))
-    ]
+
+    outputs = []
+
+    # infer shape from first chunk
+    first = chunks[0]["data"]
+
+    for i in range(len(first)):
+        chunk_arr = first[i]
+
+        if chunk_arr.ndim == 2:
+            shape = (h, w)
+        else:
+            shape = (h, w) + chunk_arr.shape[2:]
+
+        outputs.append(
+            np.zeros(shape, dtype=output_profiles[i]["dtype"])
+        )
 
     for chunk in chunks:
         tile = chunk["tile"]
+
+        ys = slice(tile.start_y, tile.end_y + 1)
+        xs = slice(tile.start_x, tile.end_x + 1)
+
         for i in range(len(outputs)):
-            outputs[i][
-                tile.start_y : tile.end_y + 1,
-                tile.start_x : tile.end_x + 1,
-            ] = chunk["data"][i].copy()
+            if outputs[i].ndim == 2:
+                outputs[i][ys, xs] = chunk["data"][i]
+            else:
+                outputs[i][ys, xs, ...] = chunk["data"][i]
 
     return outputs
 

--- a/slurp/prepare/prepare.py
+++ b/slurp/prepare/prepare.py
@@ -268,7 +268,7 @@ def create_valid_stack(
     # ==========================================================
     # Take the first band as it's the only one required for calc mask
     # ==========================================================
-    input_keys = [key_vhr[0]]
+    input_keys = [key_vhr]
     
     input_profile = deepcopy(profile)
     output_profile = eo_utils.single_uint8_profile(
@@ -277,7 +277,7 @@ def create_valid_stack(
 
     if args.cloud_mask:
         key_cloud_mask = read(args.cloud_mask)
-        input_keys = [key_vhr[0], key_cloud_mask[0]]
+        input_keys = [key_vhr, key_cloud_mask[0]]
 
     valid_stack_key = mp_n_to_m_images(
         inputs=input_keys,


### PR DESCRIPTION
Fixing prepare.py in order to handle all tests in test_features_prepare.py
Updated slurp executor in order to handle >1 Bands in "inputs" argument when calling mp_n_to_m_images

# **Future devs shall include**
- Extend this logic with mp_n_to_m_scalars
- Pass all bands as a single VHR image in *_mask.py

#  Coverage
```
Name                                        Stmts   Miss  Cover
---------------------------------------------------------------
slurp/__init__.py                               7      0   100%
slurp/eomultiprocessing/__init__.py             0      0   100%
slurp/eomultiprocessing/slurp_executor.py     205    141    31%
slurp/eomultiprocessing/slurp_manager.py       46     16    65%
slurp/eomultiprocessing/utils.py               52     17    67%
slurp/masks/__init__.py                         7      0   100%
slurp/masks/shadowmask.py                     135      7    95%
slurp/masks/stack_masks.py                    220     13    94%
slurp/masks/urbanmask.py                      265     32    88%
slurp/masks/vegetationmask.py                 382     65    83%
slurp/masks/watermask.py                      360     32    91%
slurp/post_process/__init__.py                  0      0   100%
slurp/post_process/morphology.py               32      4    88%
slurp/prepare/__init__.py                       7      0   100%
slurp/prepare/analyse_glcm.py                  73      9    88%
slurp/prepare/aux_files.py                      7      0   100%
slurp/prepare/geometry.py                     110      2    98%
slurp/prepare/prepare.py                      227     29    87%
slurp/prepare/primitives.py                    29      0   100%
slurp/prepare/validity.py                       7      1    86%
slurp/tools/__init__.py                         7      0   100%
slurp/tools/constant.py                         7      0   100%
slurp/tools/eoscale_utils.py                   80     52    35%
slurp/tools/io_utils.py                        30      7    77%
slurp/tools/misc.py                            26     26     0%
slurp/tools/mylogger.py                        27     14    48%
slurp/tools/profile_utils.py                   78     20    74%
slurp/tools/pydantic_class.py                 144      0   100%
slurp/tools/random_forest_utils.py             23      0   100%
slurp/tools/utils.py                           56      7    88%
---------------------------------------------------------------
TOTAL                                        2649    494    81%
```